### PR TITLE
Prevent Unexpected GC of Valid GodotObject

### DIFF
--- a/src/Godot.Bindings/Core/GodotObject.cs
+++ b/src/Godot.Bindings/Core/GodotObject.cs
@@ -13,7 +13,7 @@ partial class GodotObject : IDisposable
     internal nint NativePtr;
     private readonly GCHandle _gcHandle;
 
-    private readonly WeakReference<GodotObject>? _weakReferenceToSelf;
+    private readonly WeakReference<RefCounted>? _weakReferenceToSelf;
 
     private bool _disposed;
 
@@ -206,10 +206,7 @@ partial class GodotObject : IDisposable
             NativePtr = 0;
         }
 
-        if (_weakReferenceToSelf is not null)
-        {
-            DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
-        }
+        DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
     }
 
     /// <summary>


### PR DESCRIPTION
GC may accidentally collect a GodotObject instance since DisposablesTracker only holds a `WeakReference` to it.

While the `DisposablesTracker` has applied a similar mechanism in the `GodotSharp`, a direct reference to the GodotObject instance is retained in `CustomGCHandle` to keep the GodotObject alive.

`godot-dotnet` currently does not implement such `CustomGCHandle`, so I added a direct reference to the GodotObject instance in the `DisposablesTracker` instead. Still, the `RefCounted` instance continues to hold a weak reference, just like what `GodotSharp` does.