### PR TITLE
feat: add warning if a godot class does not extend from the correct base type

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -187,4 +187,9 @@ if [[ -n "$properties" ]]; then
   args+=("$properties")
 fi
 
-python ${args[@]}
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Once again, macOS is a special case :P
+  python3 ${args[@]}
+else
+  python ${args[@]}
+fi

--- a/src/Godot.SourceGenerators/Diagnostics.cs
+++ b/src/Godot.SourceGenerators/Diagnostics.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis;
+
+namespace Godot.SourceGenerators;
+
+internal static class Diagnostics
+{
+    public const string ERR_PREFIX = "GODOT_";
+    public const string ERR_CATEGORY = "Godot.SourceGenerators";
+
+    public static Diagnostic ClassDoesNotHaveCorrectBaseType(
+        Location location,
+        GodotClassSpec spec
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                $"{ERR_PREFIX}000",
+                "Class Does Not Have Correct Base Type",
+                messageFormat: "The class `{0}` does not derive from Godot.GodotObject.",
+                category: ERR_CATEGORY,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true
+            ),
+            location,
+            spec.FullyQualifiedSymbolName
+        );
+    }
+}

--- a/src/Godot.SourceGenerators/SpecCollectors/ClassSpecCollector.cs
+++ b/src/Godot.SourceGenerators/SpecCollectors/ClassSpecCollector.cs
@@ -17,6 +17,8 @@ internal static class ClassSpecCollector
         List<GodotPropertySpec> properties = [];
         List<GodotMethodSpec> methods = [];
         List<GodotSignalSpec> signals = [];
+        bool isGodotObject = typeSymbol.DerivesFrom(KnownTypeNames.GodotObject);
+        Location location = typeSymbol.Locations[0];
 
         // Initialize constructor spec if the class is instantiable.
         if (!typeSymbol.IsAbstract)
@@ -126,6 +128,8 @@ internal static class ClassSpecCollector
             Properties = [.. properties],
             Methods = [.. methods],
             Signals = [.. signals],
+            IsGodotObject = isGodotObject,
+            LocationInSource = location,
         };
     }
 }


### PR DESCRIPTION
This makes it so that if you add `[GodotClass]` to an object which does not derive from `Godot.GodotObject`, you get a nice little error telling you so.

I did not see any existing infrastructure for error reporting / diagnostics in the source generators, so I took the liberty of adding some. Feel free to request refactors.

Caveats:

Even though the `BindMethodsGenerator` now reports when you make a `[GodotClass]` that does not derive from `Godot.GodotObject`, the `EntryPointGenerator` does not perform the same validation and thus cannot filter out invalid declarations when registering types with the engine, so the build still fails (but at least you know why, now).

This could potentially be remedied in the future by combining these generators into one incremental pipeline (not sure about the potential performance), or performing equivalent validation in the `EntryPointGenerator` (i.e., create redundant code).

This also adds a fix to the `build.sh` script for macOS, since the default location of python 3 is called `python3` on macOS .