### PR TITLE
Fix invalid source generation in BindMethods

### DIFF
--- a/src/Godot.SourceGenerators/BindMethodsWriter.cs
+++ b/src/Godot.SourceGenerators/BindMethodsWriter.cs
@@ -157,7 +157,7 @@ internal static class BindMethodsWriter
             return;
         }
 
-        sb.AppendLine($"""context.SetIcon("{spec.IconPath}")""");
+        sb.AppendLine($"""context.SetIcon("{spec.IconPath}");""");
     }
 
     private static void WriteBindConstructor(IndentedStringBuilder sb, GodotClassSpec spec)


### PR DESCRIPTION
Using `[GodotClass(Icon = "Icon")]` lead to invalid code.