### PR TITLE
Fix CS0108 when several GodotClass are present in the hierarchy

### DIFF
--- a/src/Godot.SourceGenerators/BindMethodsWriter.cs
+++ b/src/Godot.SourceGenerators/BindMethodsWriter.cs
@@ -39,7 +39,9 @@ internal static class BindMethodsWriter
 
         WriteCachedStringNames(sb, spec);
 
+        sb.AppendLineNoTabs("#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.");
         sb.AppendLine("internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)");
+        sb.AppendLineNoTabs("#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.");
         sb.OpenBlock();
 
         WriteSetIcon(sb, spec);

--- a/src/Godot.SourceGenerators/IndentedStringBuilder.cs
+++ b/src/Godot.SourceGenerators/IndentedStringBuilder.cs
@@ -56,6 +56,12 @@ internal class IndentedStringBuilder
         _indentationPending = true;
     }
 
+    public void AppendLineNoTabs(string value)
+    {
+        _sb.AppendLine(value);
+        _indentationPending = true;
+    }
+
     private void AppendIndentationIfNeeded()
     {
         if (!_indentationPending)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.MyNode.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.MyNode.generated.cs
@@ -19,7 +19,9 @@ partial class MyNode
     {
         public static global::Godot.StringName @MySignal { get; } = global::Godot.StringName.CreateStaticFromAscii("MySignal"u8);
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => MyNode.@MyConstructorMethod());
         context.BindMethod(MethodName.@MyMethod,

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.Node2.Node3.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.Node2.Node3.generated.cs
@@ -21,7 +21,9 @@ partial class Node1
             public new partial class SignalName : global::Godot.Node.SignalName
             {
             }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
             internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
             {
                 context.BindConstructor(() => new Node3());
                 context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@Node3Property, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.Node2.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.Node2.generated.cs
@@ -19,7 +19,9 @@ partial class Node1
         public new partial class SignalName : global::Godot.Node.SignalName
         {
         }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
         internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
         {
             context.BindConstructor(() => new Node2());
             context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@Node2Property, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.Node1.generated.cs
@@ -17,7 +17,9 @@ partial class Node1
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new Node1());
         context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@Node1Property, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithConstants.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithConstants.generated.cs
@@ -48,7 +48,9 @@ partial class NodeWithConstants
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithConstants());
         context.BindConstant(new global::Godot.Bridge.ConstantInfo(ConstantName.@MyConstant, (long)(@MyConstant)));

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithDefaultMarshalling.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithDefaultMarshalling.generated.cs
@@ -98,7 +98,9 @@ partial class NodeWithDefaultMarshalling
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithDefaultMarshalling());
         context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@PropertyByte, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Byte)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithGroupedProperties.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithGroupedProperties.generated.cs
@@ -24,7 +24,9 @@ partial class NodeWithGroupedProperties
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithGroupedProperties());
         context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@UngroupedProperty, global::Godot.VariantType.String)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithMethods.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithMethods.generated.cs
@@ -32,7 +32,9 @@ partial class NodeWithMethods
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithMethods());
         context.BindMethod(MethodName.@MyMethod,

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithProperties.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithProperties.generated.cs
@@ -22,7 +22,9 @@ partial class NodeWithProperties
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithProperties());
         context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@MyProperty, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithSignals.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithSignals.generated.cs
@@ -21,7 +21,9 @@ partial class NodeWithSignals
         public static global::Godot.StringName @MySignalWithNamedParameters { get; } = global::Godot.StringName.CreateStaticFromAscii("MySignalWithNamedParameters"u8);
         public static global::Godot.StringName @MySignalWithOptionalParameters { get; } = global::Godot.StringName.CreateStaticFromAscii("MySignalWithOptionalParameters"u8);
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithSignals());
         context.BindSignal(new global::Godot.Bridge.SignalInfo(SignalName.@MySignal));

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithSpeciallyRecognizedMarshalling.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithSpeciallyRecognizedMarshalling.generated.cs
@@ -28,7 +28,9 @@ partial class NodeWithSpeciallyRecognizedMarshalling
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new NodeWithSpeciallyRecognizedMarshalling());
         context.BindMethod(MethodName.@MethodThatTakesArrayOfInts,

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.ParameterDefaultValues.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.ParameterDefaultValues.generated.cs
@@ -20,7 +20,9 @@ partial class ParameterDefaultValues
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new ParameterDefaultValues());
         context.BindMethod(MethodName.@Method1,

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceA.ClassOne.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceA.ClassOne.generated.cs
@@ -16,7 +16,9 @@ partial class ClassOne
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new ClassOne());
     }

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceA.NamespaceB.MyNestedNamespacesNode.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceA.NamespaceB.MyNestedNamespacesNode.generated.cs
@@ -16,7 +16,9 @@ partial class MyNestedNamespacesNode
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new MyNestedNamespacesNode());
     }

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceB.ClassTwo.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NamespaceB.ClassTwo.generated.cs
@@ -16,7 +16,9 @@ partial class ClassTwo
     public new partial class SignalName : global::Godot.Node.SignalName
     {
     }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     internal static void BindMethods(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
         context.BindConstructor(() => new ClassTwo());
     }


### PR DESCRIPTION
Simply using a `#pragma`, as we discussed. Closes #32.