### PR TITLE
Feature : Handle the hint and hint string for the BindProperty attribute

### DIFF
--- a/src/Godot.Bindings/Core/Attributes/BindPropertyAttribute.cs
+++ b/src/Godot.Bindings/Core/Attributes/BindPropertyAttribute.cs
@@ -16,6 +16,18 @@ public sealed class BindPropertyAttribute : Attribute
     public string? Name { get; init; }
 
     /// <summary>
+    /// Specifies the hint that will be used to register the property.
+    /// If unspecified it will use the hint calculated from the property type.
+    /// </summary>
+    public PropertyHint Hint { get; init; } = PropertyHint.None;
+
+    /// <summary>
+    /// Specifies the hint string that will be used to register the property.
+    /// If unspecified it will use the hint string calculated from the property type.
+    /// </summary>
+    public string? HintString { get; init; }
+
+    /// <summary>
     /// Specifies the marshaller type that will be used to marshal this property.
     /// If unspecified the default marshaller for the annotated property's type
     /// will be used instead. If there is no default marshaller, a marshaller must

--- a/src/Godot.SourceGenerators/BindMethodsWriter.cs
+++ b/src/Godot.SourceGenerators/BindMethodsWriter.cs
@@ -524,13 +524,13 @@ internal static class BindMethodsWriter
 
         List<string> lines = [];
 
-        if (marshalInfo.Hint != PropertyHint.None)
+        if (property.HintOverride != PropertyHint.None || marshalInfo.Hint != PropertyHint.None)
         {
-            lines.Add($"Hint = {marshalInfo.Hint.FullNameWithGlobal()},");
+            lines.Add($"Hint = {(property.HintOverride == PropertyHint.None ? marshalInfo.Hint : property.HintOverride).FullNameWithGlobal()},");
         }
-        if (!string.IsNullOrEmpty(marshalInfo.HintString))
+        if (!string.IsNullOrEmpty(property.HintStringOverride) || !string.IsNullOrEmpty(marshalInfo.HintString))
         {
-            lines.Add($"""HintString = "{marshalInfo.HintString}",""");
+            lines.Add($"""HintString = "{property.HintStringOverride ?? marshalInfo.HintString}",""");
         }
         if (marshalInfo.Usage != PropertyUsageFlags.None)
         {

--- a/src/Godot.SourceGenerators/SpecCollectors/PropertySpecCollector.cs
+++ b/src/Godot.SourceGenerators/SpecCollectors/PropertySpecCollector.cs
@@ -88,6 +88,8 @@ internal static class PropertySpecCollector
     private static GodotPropertySpec CollectCore(Compilation compilation, string symbolName, ITypeSymbol typeSymbol, AttributeData? attribute, CancellationToken cancellationToken = default)
     {
         string? nameOverride = null;
+        PropertyHint hintOverride =  PropertyHint.None;
+        string? hintStringOverride = null;
 
         if (attribute is not null)
         {
@@ -97,6 +99,15 @@ internal static class PropertySpecCollector
                 {
                     case "Name":
                         nameOverride = constant.Value as string;
+                        break;
+                    case "Hint":
+                        if (constant.Value is long longValue)
+                        {
+                            hintOverride = (PropertyHint)longValue;
+                        }
+                        break;
+                    case "HintString":
+                        hintStringOverride = constant.Value as string;
                         break;
                 }
             }
@@ -110,6 +121,8 @@ internal static class PropertySpecCollector
             FullyQualifiedTypeName = typeSymbol.FullNameWithGlobal(),
             MarshalInfo = marshalInfo,
             NameOverride = nameOverride,
+            HintOverride = hintOverride,
+            HintStringOverride = hintStringOverride
         };
     }
 }

--- a/src/Godot.SourceGenerators/SpecCollectors/PropertySpecCollector.cs
+++ b/src/Godot.SourceGenerators/SpecCollectors/PropertySpecCollector.cs
@@ -88,7 +88,7 @@ internal static class PropertySpecCollector
     private static GodotPropertySpec CollectCore(Compilation compilation, string symbolName, ITypeSymbol typeSymbol, AttributeData? attribute, CancellationToken cancellationToken = default)
     {
         string? nameOverride = null;
-        PropertyHint hintOverride =  PropertyHint.None;
+        PropertyHint hintOverride = PropertyHint.None;
         string? hintStringOverride = null;
 
         if (attribute is not null)

--- a/src/Godot.SourceGenerators/Specs/GodotPropertySpec.cs
+++ b/src/Godot.SourceGenerators/Specs/GodotPropertySpec.cs
@@ -46,6 +46,20 @@ internal readonly record struct GodotPropertySpec : IEquatable<GodotPropertySpec
     public string? NameOverride { get; init; }
 
     /// <summary>
+    /// Hint specified in the <c>[BindProperty]</c> attribute for this property,
+    /// or PropertyType.None if a hint was not specified.
+    /// If unspecified the hint of the property will be calculated from the <see cref="MarshalInfo"/>.
+    /// </summary>
+    public PropertyHint HintOverride { get; init; }
+
+    /// <summary>
+    /// Hint string specified in the <c>[BindProperty]</c> attribute for this property,
+    /// or <see langword="null"/> if a hint string was not specified.
+    /// If unspecified the hint string of the property will be calculated from the <see cref="MarshalInfo"/>.
+    /// </summary>
+    public string? HintStringOverride { get; init; }
+
+    /// <summary>
     /// Group information specified in the <c>[PropertyGroup]</c> attribute,
     /// if the property is annotated to define a group from this property.
     /// </summary>

--- a/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithProperties.generated.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/GeneratedSources/NS.NodeWithProperties.generated.cs
@@ -18,6 +18,8 @@ partial class NodeWithProperties
         public static global::Godot.StringName @myField { get; } = global::Godot.StringName.CreateStaticFromAscii("myField"u8);
         public static global::Godot.StringName @myNamedField { get; } = global::Godot.StringName.CreateStaticFromAscii("my_named_field"u8);
         public static global::Godot.StringName @myFieldWithDefaultValue { get; } = global::Godot.StringName.CreateStaticFromAscii("myFieldWithDefaultValue"u8);
+        public static global::Godot.StringName @myFieldWithHintOverride { get; } = global::Godot.StringName.CreateStaticFromAscii("myFieldWithHintOverride"u8);
+        public static global::Godot.StringName @myFieldWithHintStringOverride { get; } = global::Godot.StringName.CreateStaticFromAscii("myFieldWithHintStringOverride"u8);
     }
     public new partial class SignalName : global::Godot.Node.SignalName
     {
@@ -98,6 +100,32 @@ partial class NodeWithProperties
             static (NodeWithProperties __instance, int value) =>
             {
                 __instance.@myFieldWithDefaultValue = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@myFieldWithHintOverride, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)
+            {
+                Hint = global::Godot.PropertyHint.Layers3DPhysics,
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithProperties __instance) =>
+            {
+                return __instance.@myFieldWithHintOverride;
+            },
+            static (NodeWithProperties __instance, int value) =>
+            {
+                __instance.@myFieldWithHintOverride = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyInfo(PropertyName.@myFieldWithHintStringOverride, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Int32)
+            {
+                HintString = "my_hint_string",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithProperties __instance) =>
+            {
+                return __instance.@myFieldWithHintStringOverride;
+            },
+            static (NodeWithProperties __instance, int value) =>
+            {
+                __instance.@myFieldWithHintStringOverride = value;
             });
     }
 }

--- a/tests/Godot.SourceGenerators.Tests/TestData/Sources/NodeWithProperties.cs
+++ b/tests/Godot.SourceGenerators.Tests/TestData/Sources/NodeWithProperties.cs
@@ -26,4 +26,10 @@ public partial class NodeWithProperties : Node
 
     [BindProperty]
     public int myFieldWithDefaultValue = 42;
+
+    [BindProperty(Hint = PropertyHint.Layers3DPhysics)]
+    public int myFieldWithHintOverride;
+
+    [BindProperty(HintString = "my_hint_string")]
+    public int myFieldWithHintStringOverride;
 }


### PR DESCRIPTION
This feature adds the option to specify the `Hint` and `HintString` on the `BindPropertyAttribute`.
This is useful to handle Godot special property bindings like Files, Directory, Layers3DPhysics, etc.

As of now it seems like it was possible to do it using a "Hand made" `BindMethods` using the `ClassRegistrationContext`.
I did not see a way to do it right now with source generator using the attribute, unless I missed something and there is other ways to do it.

This code was inspired by the `NameOverride` from the `CollectCore` function.

Unit tests has been done to ensure the result of the code generation.

I hope this can be useful 🙂