### PR TITLE
Update `Microsoft.Build.Utilities.Core` to 17.14.28 for security vulnerability

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <!-- System -->
     <SystemCommandLineVersion>2.0.0-beta5.25306.1</SystemCommandLineVersion>
     <!-- MSBuild -->
-    <MicrosoftBuildVersion>17.14.8</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.14.28</MicrosoftBuildVersion>
     <MicrosoftBuildLocatorVersion>1.9.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
     <!-- Roslyn -->


### PR DESCRIPTION
Akien raised an issue in which he was encountering while compiling this. This is what he got.
```$ ./build.sh --productBuild --pushNupkgsLocal ~/.nuget/local-source/ 
  Tasks failed with 1 error(s) (0.3s)
    /home/akien/Godot/godot-dotnet/eng/common/tasks/Tasks.csproj : error NU1903: Warning As Error: Package 'Microsoft.Build.Utilities.Core' 17.14.8 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
```
Microsoft also released a security advisory as a DoS (Denial of Service) attack could be carried out when using .NET in Linux. Refer to:
[Advisory](https://github.com/advisories/GHSA-w3q9-fxm7-j8fq)
I just updated the version from 17.14.8 to 17.14.28