### PR TITLE
Add the `GodotSynchronizationContext` singleton instance

### DIFF
--- a/src/Godot.Bindings/Core/GodotSynchronizationContext.cs
+++ b/src/Godot.Bindings/Core/GodotSynchronizationContext.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Godot;
 
-internal sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
+public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
 {
     private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = [];
 
@@ -65,11 +65,16 @@ internal sealed class GodotSynchronizationContext : SynchronizationContext, IDis
     }
 
     /// <summary>
+    /// A singleton instance of the synchronization context.
+    /// </summary>
+    public static readonly GodotSynchronizationContext Singleton = new();
+
+    /// <summary>
     /// Initializes the synchronization context. This should be called before any user code is executed.
     /// </summary>
     internal static void InitializeSynchronizationContext()
     {
-        SynchronizationContext.SetSynchronizationContext(new GodotSynchronizationContext());
+        SynchronizationContext.SetSynchronizationContext(Singleton);
     }
 
     /// <summary>


### PR DESCRIPTION
The `GodotSynchronizationContext` class has been made public, and a static singleton field has been added to facilitate users pushing code to the main thread for execution.  
The constructor of `GodotSynchronizationContext` remains private, and users should use the singleton instance instead of instantiating `GodotSynchronizationContext` themselves.

Why not directly use `SynchronizationContext.Current` or `CallDeferred`?  
Both can work, but each has its inconveniences:  
1. `SynchronizationContext.Current` has different values in different threads. Users need to retrieve and store it in the main thread beforehand to use it in child threads.  
2. `CallDeferred` requires wrapping the method in a `Callable`, especially for lambda methods, which necessitates calling `Callable.From` each time to create an additional wrapper.