### PR TITLE
Add [BindSharedEnum] attribute to share namespace-level enums across GDExtension classes

### DIFF
--- a/src/Godot.Bindings/Core/Attributes/BindSharedEnumAttribute.cs
+++ b/src/Godot.Bindings/Core/Attributes/BindSharedEnumAttribute.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Godot;
+
+/// <summary>
+/// Registers the constants of the specified enum type within the annotated extension class.
+/// This allows a namespace-level enum to be shared across multiple extension classes.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+public sealed class BindSharedEnumAttribute : Attribute
+{
+    /// <summary>
+    /// Constructs a new <see cref="BindSharedEnumAttribute"/> with the specified enum type.
+    /// </summary>
+    /// <param name="enumType">The enum type whose constants will be registered for this class.</param>
+    public BindSharedEnumAttribute(Type enumType)
+    {
+        EnumType = enumType;
+    }
+
+    /// <summary>
+    /// The enum type whose constants are registered for this class.
+    /// </summary>
+    public Type EnumType { get; }
+
+    /// <summary>
+    /// Specifies the name that will be used to register the enum.
+    /// If unspecified it will use the name of the enum type.
+    /// </summary>
+    public string? Name { get; init; }
+}

--- a/src/Godot.Common.CodeAnalysis/KnownTypeNames.cs
+++ b/src/Godot.Common.CodeAnalysis/KnownTypeNames.cs
@@ -94,6 +94,7 @@ internal static class KnownTypeNames
     public const string PropertySubgroupAttribute = "Godot.PropertySubgroupAttribute";
     public const string RpcAttribute = "Godot.RpcAttribute";
     public const string SignalAttribute = "Godot.SignalAttribute";
+    public const string BindSharedEnumAttribute = "Godot.BindSharedEnumAttribute";
     public const string MustBeVariantAttribute = "Godot.MustBeVariantAttribute";
     public const string DisableGodotEntryPointGenerationAttribute = "Godot.DisableGodotEntryPointGenerationAttribute";
 }

--- a/src/Godot.SourceGeneration/SpecCollectors/ClassSpecCollector.cs
+++ b/src/Godot.SourceGeneration/SpecCollectors/ClassSpecCollector.cs
@@ -115,6 +115,40 @@ internal static class ClassSpecCollector
             }
         }
 
+        // Collect shared enum constants from [BindSharedEnum] attributes.
+        foreach (var attributeData in typeSymbol.GetAttributes())
+        {
+            if (attributeData.AttributeClass?.FullQualifiedNameOmitGlobal() != KnownTypeNames.BindSharedEnumAttribute)
+            {
+                continue;
+            }
+
+            if (attributeData.ConstructorArguments.Length < 1)
+            {
+                continue;
+            }
+
+            if (attributeData.ConstructorArguments[0].Value is not INamedTypeSymbol enumTypeSymbol)
+            {
+                continue;
+            }
+
+            string? enumNameOverride = null;
+            foreach (var (key, constant) in attributeData.NamedArguments)
+            {
+                if (key == "Name")
+                {
+                    enumNameOverride = constant.Value as string;
+                }
+            }
+
+            var sharedConstantSpecs = ConstantSpecCollector.CollectShared(compilation, enumTypeSymbol, enumNameOverride, cancellationToken);
+            foreach (var constantSpec in sharedConstantSpecs)
+            {
+                constants.Add(constantSpec);
+            }
+        }
+
         // Collect property specs.
         foreach (var symbol in members)
         {

--- a/src/Godot.SourceGeneration/SpecCollectors/ConstantSpecCollector.cs
+++ b/src/Godot.SourceGeneration/SpecCollectors/ConstantSpecCollector.cs
@@ -62,6 +62,25 @@ internal static class ConstantSpecCollector
         }
     }
 
+    public static IEnumerable<GodotConstantSpec> CollectShared(Compilation compilation, ITypeSymbol enumTypeSymbol, string? enumNameOverride = null, CancellationToken cancellationToken = default)
+    {
+        if (enumTypeSymbol.TypeKind != TypeKind.Enum)
+        {
+            yield break;
+        }
+
+        string? effectiveEnumName = enumNameOverride ?? enumTypeSymbol.Name;
+
+        bool isFlagsEnum = enumTypeSymbol.HasAttribute(KnownTypeNames.SystemFlagsAttribute);
+
+        foreach (var fieldSymbol in enumTypeSymbol.GetMembers().OfType<IFieldSymbol>())
+        {
+            fieldSymbol.TryGetAttribute(KnownTypeNames.BindConstantAttribute, out var constantAttribute);
+
+            yield return CollectCore(compilation, fieldSymbol.Name, enumTypeSymbol.Name, effectiveEnumName, isFlagsEnum, constantAttribute, cancellationToken);
+        }
+    }
+
     private static GodotConstantSpec CollectCore(Compilation compilation, string symbolName, string? enumSymbolName, string? enumNameOverride, bool isFlagsEnum, AttributeData? attribute, CancellationToken cancellationToken = default)
     {
         string? nameOverride = null;


### PR DESCRIPTION
## Summary

This PR introduces `[BindSharedEnum]` — a new attribute that allows **namespace-level enums to be shared across multiple GDExtension `[GodotClass]` classes**. Before, enums registered via `[BindEnum]` must be nested inside a `[GodotClass]` because the source generator only scans class members, forcing duplication when multiple extension classes need the same enum.

### Before (enum duplicated per class)

```csharp
// Each class must declare and register its own copy of the same enum
[GodotClass]
public partial class ClassA : Node
{
    [BindEnum]
    public enum Team { Red, Green, Blue }
}

[GodotClass]
public partial class ClassB : Node
{
    [BindEnum]
    public enum Team { Red, Green, Blue }  // Duplicated!
}
```

### After (enum declared once, shared)

```csharp
// Declare once at namespace level
public enum Team { Red, Green, Blue }

[GodotClass]
[BindSharedEnum(typeof(Team))]
public partial class ClassA : Node { }

[GodotClass]
[BindSharedEnum(typeof(Team))]
public partial class ClassB : Node { }
```

```csharp
// sharing multiple enums on a single class
[GodotClass]
[BindSharedEnum(typeof(Team))]
[BindSharedEnum(typeof(ItemFlags))]
[BindSharedEnum(typeof(Status))]
public partial class Player : Node2D { }
```

## Compatibility

- Existing `[BindEnum]` on nested enums continues to work unchanged.
- `[BindSharedEnum]` only affects classes that explicitly use it.
- No breaking changes to the public API surface of `Godot.Bindings`.

## Note

I recognize that godot-dotnet may not currently be in a phase where convenience features like this are a priority, and the `[BindEnum]` pattern already covers the basic use case. If this doesn't align with the current roadmap, feel free to close without hesitation. 

Either way, thank you for your time reviewing this.