### PR TITLE
Fix RS1038 build errors in analyzer and source generator projects

### DIFF
--- a/src/Godot.Analyzers/Godot.Analyzers.csproj
+++ b/src/Godot.Analyzers/Godot.Analyzers.csproj
@@ -16,6 +16,12 @@
   <PropertyGroup>
     <!-- Nothing in lib but that's expected. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <!--
+      Suppress RS1038: this project also ships code-fix providers (see CodeFixers/) which
+      require the Workspaces package. Code fixes run in the IDE where Workspaces is available,
+      so the analyzers in this assembly aren't subject to the command-line-compilation limitation.
+    -->
+    <NoWarn>$(NoWarn);RS1038</NoWarn>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 

--- a/src/Godot.SourceGeneration/Godot.SourceGeneration.csproj
+++ b/src/Godot.SourceGeneration/Godot.SourceGeneration.csproj
@@ -16,6 +16,12 @@
   <PropertyGroup>
     <!-- Nothing in lib but that's expected. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <!--
+      Suppress RS1038: the shared Godot.Common.CodeAnalysis code (imported below) is also used
+      by projects that require the Workspaces package, so it references it. This generator does
+      not use any Workspaces APIs, so the reference is harmless during command-line compilation.
+    -->
+    <NoWarn>$(NoWarn);RS1038</NoWarn>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem

Building the repository from a clean checkout (`build.cmd`/`build.sh`) with the pinned .NET SDK fails with `RS1038` errors in `Godot.Analyzers` and `Godot.SourceGeneration`:

```
error RS1038: This compiler extension should not be implemented in an assembly
containing a reference to Microsoft.CodeAnalysis.Workspaces. ...
```

Both projects set `EnforceExtendedAnalyzerRules` and import the shared `Godot.Common.CodeAnalysis` code, which references `Microsoft.CodeAnalysis.CSharp.Workspaces`. RS1038 flags this because the Workspaces assembly is not available during command-line compilation.

## Fix

Suppress `RS1038` in both projects with an explanatory comment, matching the convention already used in `Godot.UpgradeAssistant.Providers`:

- `Godot.Analyzers` genuinely needs Workspaces for its code-fix providers (`CodeFixers/`), which run in the IDE where Workspaces *is* available.
- `Godot.SourceGeneration` inherits the reference through the shared code but does not use any Workspaces APIs, so the reference is harmless during command-line compilation.

## Alternative considered

I also tried moving the Workspaces reference out of the shared `Godot.Common.CodeAnalysis.projitems` (so the source generator would not reference Workspaces at all). This resolves RS1038, but removing that reference also removes a version anchor and the dependency graph falls back to a very old, .NET Framework-only `Microsoft.CodeAnalysis.CSharp.Workspaces 1.0.1`, producing `NU1701` errors. A proper split of the shared analysis code (so analyzers and code fixes live in separate assemblies) would be a larger change.

## Testing

Verified locally on Windows with .NET SDK 10.0.103: `build.cmd` now compiles `Godot.Analyzers` and `Godot.SourceGeneration` with no RS1038 errors, and the unit test suite passes.
