### PR TITLE
Fix malformed XML doc comments from BBCode inside code blocks

### DIFF
--- a/src/Godot.BindingsGeneration/Utils/XmlDocConverter.cs
+++ b/src/Godot.BindingsGeneration/Utils/XmlDocConverter.cs
@@ -44,36 +44,46 @@ internal sealed class XmlDocConverter
             switch (parser.TokenType)
             {
                 case BBCodeTokenType.Text:
+                    if (inCodeTag)
+                    {
+                        // Inside a [code]/[codeblock]/[csharp] block, preserve the text exactly as-is.
+                        sb.AppendEscapedXml(parser.ValueSpan);
+                        break;
+                    }
+
                     if (inCodeBlocksTag)
                     {
-                        // We are inside a [codeblocks] tag, ignore all text until we find
-                        // the end tag [/codeblocks] or the [csharp][/csharp] tags.
+                        // Inside a [codeblocks] wrapper but not its active code section (e.g. the
+                        // [gdscript] block); ignore the text.
                         continue;
                     }
 
+                    // Normal prose: split into paragraphs.
                     ReadOnlySpan<char> textSpan = parser.ValueSpan;
-                    if (inCodeTag)
+                    int newLineIndex;
+                    while ((newLineIndex = textSpan.IndexOf('\n')) != -1)
                     {
-                        // We are inside a [code] or [csharp] tag, preserve the text exactly as-is.
-                        sb.AppendEscapedXml(textSpan);
+                        sb.AppendEscapedXml(textSpan.Slice(0, newLineIndex));
+                        sb.AppendLine("</para>");
+                        sb.Append("<para>");
+                        textSpan = textSpan.Slice(newLineIndex + 1);
                     }
-                    else
-                    {
-                        // We are outside of a [code] or [csharp] tag, so we need to split the text into paragraphs.
-                        int newLineIndex;
-                        while ((newLineIndex = textSpan.IndexOf('\n')) != -1)
-                        {
-                            sb.AppendEscapedXml(textSpan.Slice(0, newLineIndex));
-                            sb.AppendLine("</para>");
-                            sb.Append("<para>");
-                            textSpan = textSpan.Slice(newLineIndex + 1);
-                        }
-                        sb.AppendEscapedXml(textSpan);
-                    }
+                    sb.AppendEscapedXml(textSpan);
                     break;
 
                 case BBCodeTokenType.StartTag:
                     var startTag = parser.GetStartTag();
+
+                    // When we're inside a code context, recognized inline tags (e.g. [b], [i], [url])
+                    // must be preserved as literal text instead of being emitted as XML elements.
+                    // Otherwise an array subscript like 'a[i]' would emit a stray <i> element and
+                    // produce malformed XML doc comments (CS1570). Only the tags that manage the code
+                    // state fall through to the switch below so the block can still be opened/closed.
+                    if (TryHandleTagInCodeContext(sb, startTag.TagName, parser.ValueSpan, inCodeTag, inCodeBlocksTag))
+                    {
+                        continue;
+                    }
+
                     switch (startTag.TagName)
                     {
                         case "b":
@@ -178,26 +188,10 @@ internal sealed class XmlDocConverter
 
                         case "csharp":
                             sb.Append("<code>");
-                            inCodeBlocksTag = false;
                             inCodeTag = true;
                             break;
 
                         default:
-                            if (inCodeBlocksTag)
-                            {
-                                // We are inside a [codeblocks] tag, ignore all text until we find
-                                // the end tag [/codeblocks] or the [csharp][/csharp] tags.
-                                continue;
-                            }
-
-                            if (inCodeTag)
-                            {
-                                // We are inside a [codeblock] or [csharp] tag,
-                                // preserve the text exactly as-is, including unrecognized tags.
-                                sb.AppendEscapedXml(parser.ValueSpan);
-                                continue;
-                            }
-
                             // Check if this tag is one of the reference tags.
                             if (TryAppendReference(sb, startTag, currentType))
                             {
@@ -217,6 +211,16 @@ internal sealed class XmlDocConverter
                     // We only need to check for the end tags that aren't self-closing.
                     // We also consume some end tags in the StartTag case, so those won't show up here either.
                     var endTag = parser.GetEndTag();
+
+                    // Mirror the StartTag handling: inside a code context, recognized inline end tags
+                    // (e.g. [/b], [/i]) must be preserved as literal text instead of being emitted as
+                    // XML elements. Only the tags that manage the code state fall through to the switch
+                    // below so the code block can still be closed correctly.
+                    if (TryHandleTagInCodeContext(sb, endTag.TagName, parser.ValueSpan, inCodeTag, inCodeBlocksTag))
+                    {
+                        continue;
+                    }
+
                     switch (endTag.TagName)
                     {
                         case "b":
@@ -247,21 +251,21 @@ internal sealed class XmlDocConverter
 
                         case "codeblocks":
                             inCodeBlocksTag = false;
+                            if (inCodeTag)
+                            {
+                                // A [csharp]/[codeblock] block was left open (malformed input); close its
+                                // <code> element so we don't emit unbalanced XML.
+                                sb.Append("</code>");
+                                inCodeTag = false;
+                            }
                             break;
 
                         case "csharp":
                             sb.Append("</code>");
-                            inCodeBlocksTag = true;
+                            inCodeTag = false;
                             break;
 
                         default:
-                            if (inCodeBlocksTag)
-                            {
-                                // We are inside a [codeblocks] tag, ignore all text until we find
-                                // the end tag [/codeblocks] or the [csharp][/csharp] tags.
-                                continue;
-                            }
-
                             // Unrecognized end tag, just output the raw text.
                             sb.AppendEscapedXml(parser.ValueSpan);
                             break;
@@ -273,6 +277,39 @@ internal sealed class XmlDocConverter
         sb.AppendLine("</para>");
         sb.AppendLine("</summary>");
         return sb.ToString();
+    }
+
+    private static bool IsCodeStateTag(ReadOnlySpan<char> tagName) => tagName switch
+    {
+        // These tags open or close a code context, so they must always be handled (to emit or
+        // close the <code> element and toggle the state flags) even while we're inside a code
+        // context passing every other tag through as literal text.
+        "codeblock" => true,
+        "codeblocks" => true,
+        "csharp" => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Handles a tag encountered while inside a code context. Recognized tags are preserved as
+    /// literal text inside a [code]/[codeblock]/[csharp] block, or ignored inside the non-active
+    /// section of a [codeblocks] block. Returns <see langword="true"/> if the tag was handled and
+    /// the caller should skip its normal processing.
+    /// </summary>
+    private static bool TryHandleTagInCodeContext(StringBuilder sb, ReadOnlySpan<char> tagName, ReadOnlySpan<char> rawTag, bool inCodeTag, bool inCodeBlocksTag)
+    {
+        if ((!inCodeTag && !inCodeBlocksTag) || IsCodeStateTag(tagName))
+        {
+            return false;
+        }
+
+        if (inCodeTag)
+        {
+            // Inside a code block: preserve the tag as literal text.
+            sb.AppendEscapedXml(rawTag);
+        }
+        // else: inside a [codeblocks] wrapper but not its active code section -> ignore.
+        return true;
     }
 
     private ref struct Reference

--- a/tests/Godot.BindingsGeneration.Tests/XmlDocConverterTests.cs
+++ b/tests/Godot.BindingsGeneration.Tests/XmlDocConverterTests.cs
@@ -99,6 +99,176 @@ public class XmlDocConverterTests
     }
 
     [Fact]
+    public void CodeblockTagPreservesArraySubscripts()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        string? actual = xmlDocConverter.Convert("""
+            [codeblock]
+            result[i] = a[i] + b[i];
+            [/codeblock]
+            """);
+
+        string expected = """
+            <summary>
+            <para><code>
+            result[i] = a[i] + b[i];
+            </code></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void CodeblockTagPreservesRecognizedInlineTags()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        string? actual = xmlDocConverter.Convert("""
+            [codeblock]
+            x[b]y[i]z
+            [/codeblock]
+            """);
+
+        string expected = """
+            <summary>
+            <para><code>
+            x[b]y[i]z
+            </code></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("[code]a[i][/code]", "<c>a[i]</c>")]
+    [InlineData("[code]x[b]y[/code]", "<c>x[b]y</c>")]
+    public void InlineCodeTagPreservesBBCode(string input, string expected)
+    {
+        // The converter wraps the output in a <summary> and <para> tags for each line.
+        expected = $"""
+            <summary>
+            <para>{expected}</para>
+            </summary>
+
+            """;
+
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+        string? actual = xmlDocConverter.Convert(input);
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void CodeblocksTagKeepsCSharpAndDropsGDScript()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // The [gdscript] half is dropped and only the [csharp] half becomes a <code> block.
+        // The array subscripts in the C# code must be preserved literally (no <i> elements).
+        string? actual = xmlDocConverter.Convert(
+            "[codeblocks][gdscript]result[i] = gd[i];[/gdscript][csharp]result[i] = a[i];[/csharp][/codeblocks]");
+
+        string expected = """
+            <summary>
+            <para><code>result[i] = a[i];</code></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void CodeblocksTagDoesNotLeakCodeStateIntoTrailingProse()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // After the [codeblocks] block closes, the code state must be fully reset so the trailing
+        // prose is parsed normally: the [b] tag renders as <b>, not as literal text.
+        string? actual = xmlDocConverter.Convert("""
+            [codeblocks][csharp]x[i];[/csharp][/codeblocks]
+            See [b]bold[/b].
+            """);
+
+        string expected = """
+            <summary>
+            <para><code>x[i];</code></para>
+            <para>See <b>bold</b>.</para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void TopLevelCSharpTagDoesNotDropTrailingProse()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // A top-level [csharp] block (not wrapped in [codeblocks]) must not leave the code state
+        // stuck: after [/csharp] closes the block, the trailing prose is parsed normally and the
+        // [b] tag renders as <b>, not dropped as if we were still inside a [codeblocks] wrapper.
+        string? actual = xmlDocConverter.Convert("""
+            [csharp]var x = 1;[/csharp]
+            See [b]docs[/b].
+            """);
+
+        string expected = """
+            <summary>
+            <para><code>var x = 1;</code></para>
+            <para>See <b>docs</b>.</para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void UnclosedCSharpInCodeblocksClosesCodeElement()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // Malformed input: the [csharp] block is never closed with [/csharp] before [/codeblocks].
+        // The [/codeblocks] end tag must close the still-open <code> element so we don't emit
+        // unbalanced XML (a dangling <code> would produce CS1570).
+        string? actual = xmlDocConverter.Convert("[codeblocks][csharp]code[/codeblocks]");
+
+        string expected = """
+            <summary>
+            <para><code>code</code></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void CodeblockNestedInCodeblocksPreservesBody()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // A singular [codeblock] nested inside a [codeblocks] wrapper is an active code section,
+        // so its body must be preserved inside <code>, not dropped as non-active [codeblocks] text.
+        string? actual = xmlDocConverter.Convert("[codeblocks][codeblock]example[/codeblock][/codeblocks]");
+
+        string expected = """
+            <summary>
+            <para><code>example</code></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public void References()
     {
         var typeDB = new TypeDB();


### PR DESCRIPTION
## Problem

When the bindings generator converts Godot's BBCode documentation into C# XML doc comments, recognized inline tags (`[b]`, `[i]`, `[u]`, `[br]`, `[url]`, …) are emitted as real XML elements **even inside a `[codeblock]`/`[csharp]` block**. Text that merely looks like a tag, most commonly an array subscript such as `a[i]` in shader code is turned into a stray `<i>` element, producing unbalanced XML.

For example, `VisualShaderNodeColorOp`'s `OP_OVERLAY` docs contain:

```gdscript
result[i] = 2.0 * base * blend;
```

which generated `result<i> = 2.0 * base * blend;` inside `<code>`, so compiling `Godot.Bindings` with `GenerateDocumentationFile=true` fails with errors like:

```
error CS1570: XML comment has badly formed XML -- 'End tag 'code' does not match the start tag 'i'.'
```

## Fix

- Hoist the existing code-context guard above **both** the start-tag and end-tag switches in `XmlDocConverter`, so that inside a code context every tag except the ones that manage the code state (`codeblock`/`codeblocks`/`csharp`) is preserved as literal text, matching how unrecognized tags were already handled.
- Reset the code-element state (`inCodeTag`) when closing a `[csharp]`/`[codeblocks]` block. Previously it was left set, so prose following a `[codeblocks]` block was treated as if still inside a code block (a latent bug the guard above would otherwise have made visible in trailing prose).

## Tests

Added to `XmlDocConverterTests`:

- Array subscripts (`a[i]`, `result[i]`) preserved literally inside `[codeblock]`.
- Recognized inline tags (`[b]`, `[i]`) preserved literally inside `[codeblock]`.
- Inline `[code]` round-trips BBCode-looking content.
- `[codeblocks]` keeps the `[csharp]` half and drops the `[gdscript]` half, with subscripts preserved.
- Prose after a `[codeblocks]` block is no longer treated as in-code (a trailing `[b]` renders as `<b>`).

`dotnet test tests/Godot.BindingsGeneration.Tests` passes (13 converter tests, including the pre-existing ones).

## Scope

This addresses the **malformed-XML (CS1570)** category only. Other generated-doc issues surfaced by `GenerateDocumentationFile=true` like ambiguous `cref` references (CS0419) for overloaded methods are independent and left for separate follow-up.
