### PR TITLE
Validate parameter references before emitting paramref in doc comments

### DIFF
--- a/src/Godot.BindingsGeneration/BindingsGenerator/BindingsData.cs
+++ b/src/Godot.BindingsGeneration/BindingsGenerator/BindingsData.cs
@@ -148,7 +148,9 @@ internal sealed partial class BindingsData
             {
                 if (!string.IsNullOrEmpty(constructor.Documentation))
                 {
-                    constructor.Documentation = converter.Convert(constructor.Documentation, currentType);
+                    // Pass the constructor's parameters so '[param]' references can be
+                    // resolved to '<paramref>' only when they match an actual parameter.
+                    constructor.Documentation = converter.Convert(constructor.Documentation, currentType, constructor.Parameters);
                 }
             }
 
@@ -156,7 +158,9 @@ internal sealed partial class BindingsData
             {
                 if (!string.IsNullOrEmpty(method.Documentation))
                 {
-                    method.Documentation = converter.Convert(method.Documentation, currentType);
+                    // Pass the method's parameters so '[param]' references can be
+                    // resolved to '<paramref>' only when they match an actual parameter.
+                    method.Documentation = converter.Convert(method.Documentation, currentType, method.Parameters);
                 }
             }
 

--- a/src/Godot.BindingsGeneration/Utils/XmlDocConverter.cs
+++ b/src/Godot.BindingsGeneration/Utils/XmlDocConverter.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security;
 using System.Text;
@@ -22,8 +23,15 @@ internal sealed class XmlDocConverter
     /// </summary>
     /// <param name="bbCode">Original BBCode documentation.</param>
     /// <param name="currentType">Current type to resolve member references that aren't fully qualified.</param>
+    /// <param name="parameters">
+    /// The parameter list for the member whose documentation is being converted.
+    /// Used to decide whether a <c>[param]</c> reference can be emitted as a <c>&lt;paramref&gt;</c>.
+    /// When <see langword="null"/> (e.g. for signals/events, which declare no parameters, or for
+    /// members without parameters), <c>[param]</c> references fall back to <c>&lt;c&gt;</c> to avoid
+    /// emitting a <c>&lt;paramref&gt;</c> that doesn't match any parameter (CS1734).
+    /// </param>
     /// <returns>Converted XMLDoc string.</returns>
-    public string? Convert(string? bbCode, TypeInfo? currentType = null)
+    public string? Convert(string? bbCode, TypeInfo? currentType = null, IReadOnlyList<ParameterInfo>? parameters = null)
     {
         if (string.IsNullOrEmpty(bbCode))
         {
@@ -105,9 +113,7 @@ internal sealed class XmlDocConverter
                         case "kbd":
                         {
                             scoped ReadOnlySpan<char> content = ConsumeToMatchingEndTag(ref parser);
-                            sb.Append("<c>");
-                            sb.AppendEscapedXml(content);
-                            sb.Append("</c>");
+                            AppendCode(sb, content);
                             break;
                         }
 
@@ -153,15 +159,11 @@ internal sealed class XmlDocConverter
 
                                 case "^\"\"":
                                     // Special case for an empty StringName when using GDScript syntax.
-                                    sb.Append("<c>");
-                                    sb.AppendEscapedXml("\"\"");
-                                    sb.Append("</c>");
+                                    AppendCode(sb, "\"\"");
                                     break;
 
                                 default:
-                                    sb.Append("<c>");
-                                    sb.AppendEscapedXml(content);
-                                    sb.Append("</c>");
+                                    AppendCode(sb, content);
                                     break;
                             }
                             break;
@@ -199,7 +201,7 @@ internal sealed class XmlDocConverter
                             }
 
                             // Check if this tag is one of the reference tags.
-                            if (TryAppendReference(sb, startTag, currentType))
+                            if (TryAppendReference(sb, startTag, currentType, parameters))
                             {
                                 // Successfully appended a reference for this tag,
                                 // so we can move on to the next token.
@@ -309,7 +311,7 @@ internal sealed class XmlDocConverter
         }
     }
 
-    private bool TryAppendReference(StringBuilder sb, BBCodeStartTag startTag, TypeInfo? currentType)
+    private bool TryAppendReference(StringBuilder sb, BBCodeStartTag startTag, TypeInfo? currentType, IReadOnlyList<ParameterInfo>? parameters)
     {
         // HARDCODED: Special case for '@GlobalScope' and '@GDScript' references.
         if (!startTag.HasAttributes() && startTag.TagName.StartsWith('@'))
@@ -325,14 +327,25 @@ internal sealed class XmlDocConverter
 
         if (startTag.TagName.SequenceEqual("param") && startTag.HasAttributes())
         {
-            // We'll just assume the parameter corresponds to a parameter on the current method
-            // and the name will match after converting to follow C# naming conventions.
+            // The parameter name follows C# naming conventions after converting from snake_case.
             string parameterName = startTag.EnumerateAttributes().First().ToString();
             parameterName = NamingUtils.SnakeToCamelCase(parameterName);
 
-            sb.Append("<paramref name=\"");
-            sb.Append(parameterName);
-            sb.Append("\"/>");
+            // Only emit a '<paramref>' when the enclosing member actually has a parameter by
+            // that name. Otherwise (e.g. signals/events which declare no parameters, or a typo
+            // in the engine documentation) we emit a '<c>' instead to avoid generating an
+            // invalid '<paramref>' that would trigger CS1734. This matches how upstream Godot's
+            // own C# glue renders signal parameters (see godotengine/godot#65529).
+            if (parameters is not null && ContainsParameter(parameters, parameterName))
+            {
+                sb.Append("<paramref name=\"");
+                sb.Append(parameterName);
+                sb.Append("\"/>");
+            }
+            else
+            {
+                AppendCode(sb, parameterName);
+            }
             return true;
         }
 
@@ -395,9 +408,7 @@ internal sealed class XmlDocConverter
         {
             // The reference did not have a matching C# type or member,
             // so we'll just output the engine type or member name as-is.
-            sb.Append("<c>");
-            sb.Append(reference.Value);
-            sb.Append("</c>");
+            AppendCode(sb, reference.Value);
             return true;
         }
 
@@ -528,6 +539,26 @@ internal sealed class XmlDocConverter
         }
 
         return content;
+    }
+
+    private static bool ContainsParameter(IReadOnlyList<ParameterInfo> parameters, string parameterName)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (string.Equals(parameter.Name, parameterName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AppendCode(StringBuilder sb, ReadOnlySpan<char> text)
+    {
+        sb.Append("<c>");
+        sb.AppendEscapedXml(text);
+        sb.Append("</c>");
     }
 }
 

--- a/tests/Godot.BindingsGeneration.Tests/XmlDocConverterTests.cs
+++ b/tests/Godot.BindingsGeneration.Tests/XmlDocConverterTests.cs
@@ -99,6 +99,63 @@ public class XmlDocConverterTests
     }
 
     [Fact]
+    public void ParamReferenceWithValidParameterNameEmitsParamref()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // The parameter 'some_arg' converts to 'someArg' which is a valid parameter,
+        // so it should be emitted as a '<paramref>'.
+        string? actual = xmlDocConverter.Convert("[param some_arg]", parameters: [new ParameterInfo("someArg", KnownTypes.SystemInt32)]);
+
+        string expected = """
+            <summary>
+            <para><paramref name="someArg"/></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ParamReferenceWithUnknownParameterNameEmitsCode()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // The parameter 'some_arg' converts to 'someArg' which is NOT in the valid set,
+        // so it should fall back to '<c>' instead of emitting an invalid '<paramref>'.
+        string? actual = xmlDocConverter.Convert("[param some_arg]", parameters: []);
+
+        string expected = """
+            <summary>
+            <para><c>someArg</c></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ParamReferenceWithoutValidParameterNamesEmitsCode()
+    {
+        var xmlDocConverter = new XmlDocConverter(new TypeDB());
+
+        // Signals (C# events) declare no parameters and pass no valid set, so the
+        // '[param]' reference should collapse to '<c>' rather than an invalid '<paramref>'.
+        string? actual = xmlDocConverter.Convert("[param some_arg]", parameters: null);
+
+        string expected = """
+            <summary>
+            <para><c>someArg</c></para>
+            </summary>
+
+            """;
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public void References()
     {
         var typeDB = new TypeDB();


### PR DESCRIPTION
## Problem

The BBCode→XMLDoc converter turns `[param foo]` into `<paramref name="foo"/>` **unconditionally**, without checking that the enclosing member actually has a parameter named `foo`. 

Two cases produce an invalid `<paramref>`:

- **Signals** - a signal's documentation is attached to a C# `event`, which declares no parameters, so *any* `<paramref>` there is invalid. (This is the bulk of them, e.g. `Node.ChildEnteredTree`'s `[param node]`.)
- **Documentation typos** on methods.

Building `Godot.Bindings` with `GenerateDocumentationFile=true` reports **272 CS1734** ("no parameter by that name") errors.

## Fix

Thread the enclosing member's parameter list into `XmlDocConverter.Convert` (a new optional argument) and emit `<paramref>` only when the `snake_case`→`camelCase` name matches an actual parameter; otherwise fall back to `<c>…</c>`.

- Method and constructor documentation pass their parameters.
- Signals, properties, fields, enum members, and type summaries pass none, so their `[param]` references render as `<c>`.

This mirrors Godot's in-tree C# glue, which renders signal parameters exactly this way (`bindings_generator.cpp`, see [godotengine/godot#65529](https://github.com/godotengine/godot/pull/65529)). 

The `[param]` lookup and the generator's own parameter naming both use `NamingUtils.SnakeToCamelCase`, so valid method parameters match by construction and keep their `<paramref>`.

## Verification

Docs-on regenerate + build (`/p:GenerateGodotBindings=true /p:GenerateDocumentationFile=true`):

| | Before | After |
|---|---|---|
| CS1734 (bad paramref) | 272 | **0** |
| valid `<paramref>` in generated code | — | **6623 preserved** |
| CS0419 / CS1570 | 148 / 60 | 148 / 60 (unchanged) |

The 6623 surviving `<paramref>` elements confirm valid method/constructor parameters are **not** over-downgraded and only the invalid ones (signals, typos) become `<c>`. 

Three unit tests in `XmlDocConverterTests` cover the valid-parameter, unknown-parameter, and signal (no parameters) cases so no pre-existing test output changed.

## Scope

This change fixes the CS1734 category only and the remaining doc-diagnostic categories (CS1591 missing-doc) are unrelated / out of scope.

## Items to watch out for (for reviewers / follow-up)

- **Variadic parameters.** A method's variadic arguments are collected into a single C# parameter named `args`, so a `[param X]` that references the engine's original vararg name won't match the C# parameter and renders as `<c>X</c>` instead of `<paramref>`. This is a rare doc-quality downgrade (not a build error) as the engine's original vararg name isn't carried on the generated parameter to match against.
- **End-to-end coverage.** The unit tests supply the parameter list directly to `Convert`. Nothing exercises `ConvertDocumentationForType` building it from a real member (and passing none for signals/properties/etc.) and as with the sibling doc-cref PRs, the generated docs are only fully validated by a `GenerateDocumentationFile=true` build, which isn't the default. Running one in CI would guard this whole area (and would have caught the original unconditional-paramref bug).
