### PR TITLE
Fix collection marshalling registration under trimming and NativeAOT

### DIFF
--- a/src/Godot.Bindings/NativeInterop/Marshalling.cs
+++ b/src/Godot.Bindings/NativeInterop/Marshalling.cs
@@ -45,12 +45,22 @@ internal static partial class Marshalling
 
         internal static unsafe delegate*<in T, void*, void> AssignToPtrCb;
 
+        // Force T's static constructor to run so that types like GodotArray<T> and
+        // GodotDictionary<TKey, TValue> register their marshalling callbacks (the fields above)
+        // before they're marshalled. RunClassConstructor is trim/AOT-safe, unlike reflecting over
+        // Type.TypeInitializer which returns null under trimming/NativeAOT and silently skips the
+        // registration (leaving the callbacks null and marshalling unsupported). This matches the
+        // Godot mono glue (VariantUtils.generic.cs).
+        [UnconditionalSuppressMessage("Trimming", "IL2059",
+            Justification = "For bound members the source generator emits a concrete " +
+                "RunClassConstructor(typeof(...).TypeHandle) which is what actually preserves and runs the " +
+                "collection type's static constructor under trimming/NativeAOT. This generic call is a " +
+                "best-effort fallback for other paths (matching the Godot mono glue, VariantUtils.generic.cs); " +
+                "collection instantiations that are never otherwise constructed (e.g. Variant.As<T> on such a " +
+                "type) are not guaranteed under NativeAOT.")]
         static GenericConversion()
         {
-            // TODO: This won't work with trimming because the static constructors
-            // in GodotArray<T> and GodotDictionary<TKey, TValue> that initialize
-            // GenericConversion<T> could be trimmed.
-            typeof(T).TypeInitializer?.Invoke(null, null);
+            RuntimeHelpers.RunClassConstructor(typeof(T).TypeHandle);
         }
     }
 

--- a/src/Godot.SourceGeneration/BindMembersWriter.cs
+++ b/src/Godot.SourceGeneration/BindMembersWriter.cs
@@ -49,6 +49,8 @@ internal static class BindMembersWriter
         sb.AppendLineNoTabs("#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.");
         sb.OpenBlock();
 
+        WriteForceCollectionMarshallingRegistration(sb, spec);
+
         WriteSetIcon(sb, spec);
 
         WriteBindConstructor(sb, spec);
@@ -302,6 +304,90 @@ internal static class BindMembersWriter
         {
             sb.AppendLine($"context.BindConstructor(() => {constructor.FullyQualifiedBuilderTypeName}.@{constructor.MethodSymbolName}());");
         }
+    }
+
+    private static void WriteForceCollectionMarshallingRegistration(IndentedStringBuilder sb, GodotClassSpec spec)
+    {
+        // GodotArray<T> and GodotDictionary<TKey, TValue> register their Variant marshalling
+        // callbacks lazily, from their static constructors. Under trimming/NativeAOT nothing
+        // guarantees those static constructors run before the members that use them are marshalled,
+        // which would otherwise result in an 'InvalidOperationException' (marshalling not supported).
+        // Force them to run here using a concrete (trim-safe) type literal, once per distinct
+        // collection type used by a bound member (property, method parameter, method return,
+        // or signal parameter).
+
+        HashSet<string> seenTypeNames = [];
+        List<string> orderedTypeNames = [];
+
+        void Collect(MarshalInfo marshalInfo)
+        {
+            string? collectionTypeName = GetLazilyRegisteredCollectionTypeName(marshalInfo);
+            if (collectionTypeName is not null && seenTypeNames.Add(collectionTypeName))
+            {
+                orderedTypeNames.Add(collectionTypeName);
+            }
+        }
+
+        foreach (var property in spec.Properties)
+        {
+            Collect(property.MarshalInfo);
+        }
+        foreach (var method in spec.Methods)
+        {
+            foreach (var parameter in method.Parameters)
+            {
+                Collect(parameter.MarshalInfo);
+            }
+            if (method.ReturnParameter is not null)
+            {
+                Collect(method.ReturnParameter.Value.MarshalInfo);
+            }
+        }
+        foreach (var signal in spec.Signals)
+        {
+            foreach (var parameter in signal.Parameters)
+            {
+                Collect(parameter.MarshalInfo);
+            }
+        }
+
+        foreach (string collectionTypeName in orderedTypeNames)
+        {
+            sb.AppendLine($"global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof({collectionTypeName}).TypeHandle);");
+        }
+    }
+
+    /// <summary>
+    /// If <paramref name="marshalInfo"/> is marshalled as a generic <c>GodotArray&lt;...&gt;</c> or
+    /// <c>GodotDictionary&lt;...&gt;</c> (the only collection types that register their marshalling
+    /// callbacks lazily), returns a type name usable in a <c>typeof</c> expression; otherwise
+    /// returns <see langword="null"/>.
+    /// </summary>
+    private static string? GetLazilyRegisteredCollectionTypeName(MarshalInfo marshalInfo)
+    {
+        if (marshalInfo.VariantType is not (VariantType.Array or VariantType.Dictionary))
+        {
+            // Only Array/Dictionary Variant types are marshalled as GodotArray<...>/GodotDictionary<...>.
+            return null;
+        }
+
+        // The non-generic GodotArray/GodotDictionary are core Variant types that register their
+        // marshalling eagerly, so only the generic variants (with type arguments) need to be forced.
+        const string GodotArrayPrefix = "global::" + KnownTypeNames.GodotArray + "<";
+        const string GodotDictionaryPrefix = "global::" + KnownTypeNames.GodotDictionary + "<";
+
+        string marshalAsTypeName = marshalInfo.FullyQualifiedMarshalAsTypeName;
+        if (!marshalAsTypeName.StartsWith(GodotArrayPrefix, StringComparison.Ordinal)
+         && !marshalAsTypeName.StartsWith(GodotDictionaryPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Strip nullable reference type annotations ('?'): 'typeof' rejects them, and e.g.
+        // 'GodotArray<GodotObject?>' and 'GodotArray<GodotObject>' are the same runtime type (so
+        // this also dedupes them). Nullable value types (e.g. 'int?') can't be Variant-marshalable
+        // collection type arguments, so removing every '?' is safe for these type names.
+        return marshalAsTypeName.Replace("?", "");
     }
 
     private static void WriteBindMembers(IndentedStringBuilder sb, GodotClassSpec spec)

--- a/tests/Godot.Bindings.Tests/CollectionMarshallingRegistrationTests.cs
+++ b/tests/Godot.Bindings.Tests/CollectionMarshallingRegistrationTests.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using Godot.Collections;
+using Godot.NativeInterop;
+
+namespace Godot.Bindings.Tests;
+
+// Regression guard for godot-dotnet#36. GodotArray<T>/GodotDictionary<TKey, TValue> register their
+// Variant marshalling callbacks lazily, from their static constructors. Forcing the static
+// constructor to run (as the fixed Marshalling.GenericConversion<T> and the generated BindMembers
+// now do) must populate those callbacks.
+//
+// These run engine-free: RunClassConstructor triggers the static constructor without instantiating
+// a native collection, and the callback fields are populated with function pointers to managed
+// methods. They exercise the registration mechanism and its engine-safety; they pass under JIT
+// today and are not the NativeAOT/trimming repro itself.
+public class CollectionMarshallingRegistrationTests
+{
+    [Fact]
+    public unsafe void RunClassConstructorRegistersGodotArrayMarshalling()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(GodotArray<int>).TypeHandle);
+
+        Assert.True(Marshalling.GenericConversion<GodotArray<int>>.ToVariantCb != null);
+    }
+
+    [Fact]
+    public unsafe void RunClassConstructorRegistersGodotDictionaryMarshalling()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(GodotDictionary<int, int>).TypeHandle);
+
+        Assert.True(Marshalling.GenericConversion<GodotDictionary<int, int>>.ToVariantCb != null);
+    }
+}

--- a/tests/Godot.SourceGeneration.Tests/BindMembersGeneratorTests.cs
+++ b/tests/Godot.SourceGeneration.Tests/BindMembersGeneratorTests.cs
@@ -124,6 +124,18 @@ public class BindMembersGeneratorTests
     }
 
     [Fact]
+    public async Task CollectionMarshalling()
+    {
+        // Regression test for godot-dotnet#36: the generated BindMembers must force the static
+        // constructor of every distinct generic GodotArray<...>/GodotDictionary<...> used by a
+        // bound member (so their lazy marshalling registration runs under trimming/NativeAOT).
+        await Verifier.Verify(
+            ["NodeWithCollectionMarshalling.cs"],
+            ["NS.NodeWithCollectionMarshalling.generated.cs"]
+        );
+    }
+
+    [Fact]
     public async Task NestedNamespaces()
     {
         await Verifier.Verify(

--- a/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithCollectionMarshalling.generated.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithCollectionMarshalling.generated.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+namespace NS;
+
+partial class @NodeWithCollectionMarshalling
+{
+    public new partial class MethodName : global::Godot.Node.MethodName
+    {
+        public static global::Godot.StringName @MethodWithArrayParameter { get; } = global::Godot.StringName.CreateStaticFromAscii("MethodWithArrayParameter"u8);
+        public static global::Godot.StringName @MethodThatReturnsArray { get; } = global::Godot.StringName.CreateStaticFromAscii("MethodThatReturnsArray"u8);
+    }
+    public new partial class ConstantName : global::Godot.Node.ConstantName
+    {
+    }
+    public new partial class PropertyName : global::Godot.Node.PropertyName
+    {
+        public static global::Godot.StringName @ArrayProperty { get; } = global::Godot.StringName.CreateStaticFromAscii("ArrayProperty"u8);
+        public static global::Godot.StringName @DictionaryProperty { get; } = global::Godot.StringName.CreateStaticFromAscii("DictionaryProperty"u8);
+        public static global::Godot.StringName @UntypedArrayProperty { get; } = global::Godot.StringName.CreateStaticFromAscii("UntypedArrayProperty"u8);
+        public static global::Godot.StringName @UntypedDictionaryProperty { get; } = global::Godot.StringName.CreateStaticFromAscii("UntypedDictionaryProperty"u8);
+        public static global::Godot.StringName @PackedProperty { get; } = global::Godot.StringName.CreateStaticFromAscii("PackedProperty"u8);
+    }
+    public new partial class SignalName : global::Godot.Node.SignalName
+    {
+        public static global::Godot.StringName @CollectionSignal { get; } = global::Godot.StringName.CreateStaticFromAscii("CollectionSignal"u8);
+    }
+    public event CollectionSignalEventHandler @CollectionSignal
+    {
+        add => Connect(SignalName.@CollectionSignal, global::Godot.Callable.From<global::Godot.Collections.GodotArray<double>>(value.Invoke));
+        remove => Disconnect(SignalName.@CollectionSignal, global::Godot.Callable.From<global::Godot.Collections.GodotArray<double>>(value.Invoke));
+    }
+    protected void EmitSignalCollectionSignal(global::Godot.Collections.GodotArray<double> @values)
+    {
+        EmitSignal(SignalName.@CollectionSignal, [@values]);
+    }
+#pragma warning disable CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
+    internal static void BindMembers(global::Godot.Bridge.ClassRegistrationContext context)
+#pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
+    {
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, string>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<float>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<double>).TypeHandle);
+        context.BindConstructor(() => new global::NS.NodeWithCollectionMarshalling());
+        context.BindMethod(MethodName.@MethodWithArrayParameter,
+            new global::Godot.Bridge.ParameterDefinition(global::Godot.StringName.CreateStaticFromAscii("array"u8), global::Godot.VariantType.Array)
+            {
+                Hint = global::Godot.PropertyHint.TypeString,
+                HintString = "2/0:",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.GodotArray<int> @array) =>
+            {
+                __instance.@MethodWithArrayParameter(@array);
+            });
+        context.BindMethod(MethodName.@MethodThatReturnsArray,
+            new global::Godot.Bridge.ReturnDefinition(global::Godot.VariantType.Array)
+            {
+                Hint = global::Godot.PropertyHint.TypeString,
+                HintString = "3/0:",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@MethodThatReturnsArray();
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@ArrayProperty, global::Godot.VariantType.Array)
+            {
+                Hint = global::Godot.PropertyHint.TypeString,
+                HintString = "2/0:",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@ArrayProperty;
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.GodotArray<int> value) =>
+            {
+                __instance.@ArrayProperty = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@DictionaryProperty, global::Godot.VariantType.Dictionary)
+            {
+                Hint = global::Godot.PropertyHint.TypeString,
+                HintString = "2/0:;4/0:",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@DictionaryProperty;
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.GodotDictionary<int, string> value) =>
+            {
+                __instance.@DictionaryProperty = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@UntypedArrayProperty, global::Godot.VariantType.Array)
+            {
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@UntypedArrayProperty;
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.GodotArray value) =>
+            {
+                __instance.@UntypedArrayProperty = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@UntypedDictionaryProperty, global::Godot.VariantType.Dictionary)
+            {
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@UntypedDictionaryProperty;
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.GodotDictionary value) =>
+            {
+                __instance.@UntypedDictionaryProperty = value;
+            });
+        context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@PackedProperty, global::Godot.VariantType.PackedInt32Array)
+            {
+                Hint = global::Godot.PropertyHint.TypeString,
+                HintString = "2/0:",
+                Usage = global::Godot.PropertyUsageFlags.Default,
+            },
+            static (NodeWithCollectionMarshalling __instance) =>
+            {
+                return __instance.@PackedProperty;
+            },
+            static (NodeWithCollectionMarshalling __instance, global::Godot.Collections.PackedInt32Array value) =>
+            {
+                __instance.@PackedProperty = value;
+            });
+        context.BindSignal(new global::Godot.Bridge.SignalDefinition(SignalName.@CollectionSignal)
+        {
+            Parameters =
+            {
+                new global::Godot.Bridge.ParameterDefinition(global::Godot.StringName.CreateStaticFromAscii("values"u8), global::Godot.VariantType.Array)
+                {
+                    Hint = global::Godot.PropertyHint.TypeString,
+                    HintString = "3/0:",
+                    Usage = global::Godot.PropertyUsageFlags.Default,
+                },
+            },
+        });
+    }
+}

--- a/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithDefaultMarshalling.generated.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithDefaultMarshalling.generated.cs
@@ -102,6 +102,35 @@ partial class @NodeWithDefaultMarshalling
     internal static void BindMembers(global::Godot.Bridge.ClassRegistrationContext context)
 #pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<byte>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<long>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<float>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<double>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<string>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<global::NS.NodeWithDefaultMarshalling.MyEnum>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<global::NS.NodeWithDefaultMarshalling.MyFlagsEnum>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<global::Godot.Variant>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<global::Godot.GodotObject>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, byte>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, long>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, float>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, double>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, string>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, global::NS.NodeWithDefaultMarshalling.MyEnum>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, global::NS.NodeWithDefaultMarshalling.MyFlagsEnum>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, global::Godot.Variant>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<int, global::Godot.GodotObject>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<byte, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<long, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<float, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<double, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<string, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<global::NS.NodeWithDefaultMarshalling.MyEnum, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<global::NS.NodeWithDefaultMarshalling.MyFlagsEnum, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<global::Godot.Variant, int>).TypeHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotDictionary<global::Godot.GodotObject, int>).TypeHandle);
         context.BindConstructor(() => new global::NS.NodeWithDefaultMarshalling());
         context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@PropertyByte, global::Godot.VariantType.Int, global::Godot.Bridge.VariantTypeMetadata.Byte)
             {

--- a/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithNullableProperties.generated.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithNullableProperties.generated.cs
@@ -26,6 +26,7 @@ partial class @NodeWithNullableProperties
     internal static void BindMembers(global::Godot.Bridge.ClassRegistrationContext context)
 #pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<global::Godot.GodotObject>).TypeHandle);
         context.BindConstructor(() => new global::NS.NodeWithNullableProperties());
         context.BindProperty(new global::Godot.Bridge.PropertyDefinition(PropertyName.@MyNullableString, global::Godot.VariantType.String)
             {

--- a/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithSpeciallyRecognizedMarshalling.generated.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/NS.NodeWithSpeciallyRecognizedMarshalling.generated.cs
@@ -45,6 +45,7 @@ partial class @NodeWithSpeciallyRecognizedMarshalling
     internal static void BindMembers(global::Godot.Bridge.ClassRegistrationContext context)
 #pragma warning restore CS0108 // Method might already be defined higher in the hierarchy, that's not an issue.
     {
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(global::Godot.Collections.GodotArray<bool>).TypeHandle);
         context.BindConstructor(() => new global::NS.NodeWithSpeciallyRecognizedMarshalling());
         context.BindMethod(MethodName.@MethodThatTakesArrayOfInts,
             new global::Godot.Bridge.ParameterDefinition(global::Godot.StringName.CreateStaticFromAscii("array"u8), global::Godot.VariantType.PackedInt32Array)

--- a/tests/Godot.SourceGeneration.Tests/TestData/Sources/NodeWithCollectionMarshalling.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/Sources/NodeWithCollectionMarshalling.cs
@@ -1,0 +1,44 @@
+using Godot;
+using Godot.Collections;
+
+namespace NS;
+
+// Verifies that the generated BindMembers forces the static constructor of every distinct
+// generic GodotArray<...>/GodotDictionary<...> used by a bound member (so their lazy marshalling
+// registration runs under trimming/NativeAOT), while ignoring the non-generic and packed
+// collection types (which register eagerly).
+
+[GodotClass]
+public partial class NodeWithCollectionMarshalling : Node
+{
+    // Reported case: bound property whose marshal type is a generic GodotArray<T>.
+    [BindProperty]
+    public GodotArray<int> ArrayProperty { get; set; }
+
+    [BindProperty]
+    public GodotDictionary<int, string> DictionaryProperty { get; set; }
+
+    // Method parameter reuses GodotArray<int> (should be deduped with ArrayProperty).
+    [BindMethod]
+    public void MethodWithArrayParameter(GodotArray<int> array) { }
+
+    // Method return introduces a distinct collection type.
+    [BindMethod]
+    public GodotArray<float> MethodThatReturnsArray() => [];
+
+    // Non-generic GodotArray/GodotDictionary register eagerly, so no RunClassConstructor is emitted.
+    [BindProperty]
+    public GodotArray UntypedArrayProperty { get; set; }
+
+    [BindProperty]
+    public GodotDictionary UntypedDictionaryProperty { get; set; }
+
+    // Packed arrays are core Variant types, so no RunClassConstructor is emitted.
+    [BindProperty]
+    public PackedInt32Array PackedProperty { get; set; }
+
+    // Signal parameter introduces a distinct generic collection type (GodotArray<double>) not used
+    // by any other bound member, so its RunClassConstructor line is attributable to the signal walk.
+    [Signal]
+    public delegate void CollectionSignalEventHandler(GodotArray<double> values);
+}


### PR DESCRIPTION
Fixes #36.

## Problem

`GodotArray<T>` and `GodotDictionary<TKey, TValue>` register their Variant marshalling callbacks lazily, from their **static constructors** (`GenericConversion<GodotArray<T>>.ToVariantCb = …`). 

The marshalling dispatch (`GenericConversion<T>`) relies on its own static constructor to force that registration, but it did so by reflecting over `Type.TypeInitializer`:

```csharp
static GenericConversion()
{
    // TODO: This won't work with trimming ...
    typeof(T).TypeInitializer?.Invoke(null, null);
}
```

Under **trimming / NativeAOT**, `Type.TypeInitializer` returns `null` (the static-constructor metadata is stripped), so the `?.` silently no-ops, the callbacks stay null, and marshalling a member such as a `[BindProperty] public GodotArray<int>` throws `InvalidOperationException: Marshalling is not supported for the type` (#36). 

GDExtensions ship AOT (the `Summator` sample sets `<PublishAot>true</PublishAot>`; iOS forces it). 

Under plain JIT the reflection happens to work, which is why the reporter's workaround (`new GodotArray<int>()` before registering) and, on current `master`, the JIT path masks it.

## Fix

**1. Central path - match the mono glue.** Replace the reflection with the trim/AOT-safe intrinsic, as Godot's in-tree C# glue does (`VariantUtils.generic.cs`):

```csharp
static GenericConversion()
{
    RuntimeHelpers.RunClassConstructor(typeof(T).TypeHandle);
}
```

It emits `IL2059` for the generic `T`; that's suppressed locally with a justification.

**2. Source-generator hardening (the actual AOT guarantee for bound members).** The generator emits a **concrete** `RunClassConstructor(typeof(global::Godot.Collections.GodotArray<int>).TypeHandle)` at the top of a class's `BindMembers`, once per distinct generic collection type used by a bound **property, method parameter, method return, or signal parameter**. A concrete `typeof` is the ILLink/ILC intrinsic that actually *preserves* and runs the collection type's static constructor under trimming  which the generic `RunClassConstructor(typeof(T))` in Part 1 cannot do on its own. Only the generic `GodotArray<…>`/`GodotDictionary<…>` are emitted (non-generic core Variant types and `Packed*Array` register in the dispatch and are excluded).

## Verification

- `Godot.Bindings` built with its trim/AOT analyzers: the **`IL2090` at `Marshalling.cs` is gone**, no `IL2059` leaks (suppressed) and the marshalling path is IL-clean. (The one remaining trim error, `IL2075` in `GodotObject.NativeName.cs`, is pre-existing and untouched.)
- Source-generator snapshot test (fail-before/pass-after) covers a property, a deduped method parameter, a distinct return type, and a **signal parameter**, and confirms nothing is emitted for non-generic/packed members.
- Engine-free regression guard in `Godot.Bindings.Tests`; source-gen tests 22/22, bindings tests 202/202; the 19 unaffected generator snapshots regenerate byte-identically.

## Coverage and known limitations

Part 2 forces registration for every collection type reachable from a user class's generated `BindMembers` (properties, method params/returns, signal params). 

The following are **not** covered by the concrete force-init and fall back to Part 1's generic `RunClassConstructor` (safe under JIT / cctor-present runtimes, best-effort under NativeAOT):

- **Overrides of engine virtual methods** with a collection parameter as these are registered by `Godot.Bindings`' *own* generated `BindVirtualMethodOverrides`, which this user-project generator doesn't see.
- **`Variant.As<T>()` / `Callable.From<T>()` on a `GodotArray<…>`/`GodotDictionary<…>` instantiation that is never otherwise constructed** as nothing roots that closed type's static-constructor *body*, so the generic call can't restore it under NativeAOT.

**Structural direction (out of scope):** the in-tree mono generator avoids this class of bug entirely by emitting direct concrete converters (`VariantUtils.ConvertToArray<T>` / `Array<T>.CreateTakingOwnership…`) that bypass `GenericConversion`. Doing the same in godot-dotnet's generated marshalling lambdas would remove the need for a registration list that must enumerate every entry point. I am recording it here as a design note.

**Testing gap:** no test project here publishes trimmed/AOT (`IntegrationTests.TestGame` uses `EnableDynamicLoading`, JIT), so the true NativeAOT repro isn't exercised in CI so a `PublishAot=true` smoke test (register a class with a collection property/signal, round-trip a value) would be the only real regression guard, and confirming the original repro on an AOT-published GDExtension is the ideal final check (needs the Godot editor + AOT toolchain).
