### PR TITLE
Register base classes before derived classes with a topological sort

### DIFF
--- a/src/Godot.SourceGeneration/EntryPointGenerator.cs
+++ b/src/Godot.SourceGeneration/EntryPointGenerator.cs
@@ -35,36 +35,32 @@ internal sealed class EntryPointGenerator : IIncrementalGenerator
             .Where(spec => spec is not null)
             .Select((spec, ct) => spec!.Value)
             .Collect()
-            // Sort for base classes to to be registered before derived classes.
+            // Sort for base classes to be registered before derived classes.
             .Select((specs, ct) =>
             {
                 Dictionary<string, GodotRegistrationSpec> specByTypeName = [];
-                Dictionary<string, int> derivedTypeCountByBaseTypeName = [];
-
                 foreach (var spec in specs)
                 {
-                    specByTypeName.Add(spec.FullyQualifiedSymbolName, spec);
-
-                    if (!derivedTypeCountByBaseTypeName.TryGetValue(spec.FullyQualifiedSymbolName, out int derivedTypeCount))
-                    {
-                        derivedTypeCountByBaseTypeName.Add(spec.FullyQualifiedSymbolName, 0);
-                        derivedTypeCount++;
-                    }
-
-                    string baseTypeName = spec.FullyQualifiedBaseSymbolName;
-                    while (specByTypeName.TryGetValue(baseTypeName, out var baseTypeNameType))
-                    {
-                        derivedTypeCountByBaseTypeName[baseTypeName] += derivedTypeCount;
-                        baseTypeName = baseTypeNameType.FullyQualifiedBaseSymbolName;
-                    }
-
-                    derivedTypeCountByBaseTypeName.TryGetValue(baseTypeName, out int oldDerivedTypeCount);
-                    derivedTypeCountByBaseTypeName[baseTypeName] = oldDerivedTypeCount + derivedTypeCount;
+                    specByTypeName[spec.FullyQualifiedSymbolName] = spec;
                 }
 
-                return specByTypeName
-                    .OrderByDescending(kvp => derivedTypeCountByBaseTypeName[kvp.Key])
-                    .Select(kvp => kvp.Value)
+                // Number of ancestors (transitively) that are also registered in this assembly.
+                // A base type therefore has a strictly lower depth than any type deriving from it,
+                // so ordering by depth guarantees base classes register before derived classes.
+                int GetRegisteredAncestorDepth(GodotRegistrationSpec spec)
+                {
+                    int depth = 0;
+                    string baseTypeName = spec.FullyQualifiedBaseSymbolName;
+                    while (specByTypeName.TryGetValue(baseTypeName, out var baseSpec))
+                    {
+                        depth++;
+                        baseTypeName = baseSpec.FullyQualifiedBaseSymbolName;
+                    }
+                    return depth;
+                }
+
+                return specs
+                    .OrderBy(GetRegisteredAncestorDepth)
                     .ToImmutableArray();
             });
 

--- a/tests/Godot.SourceGeneration.Tests/EntryPointGeneratorTests.cs
+++ b/tests/Godot.SourceGeneration.Tests/EntryPointGeneratorTests.cs
@@ -32,4 +32,13 @@ public class EntryPointGeneratorTests
             [("Main.generated.cs", "MainWithInheritance.generated.cs")]
         );
     }
+
+    [Fact]
+    public async Task BaseTypesRegisteredBeforeDerivedTypesWhenDeclaredDerivedFirst()
+    {
+        await Verifier.Verify(
+            ["NodesWithInheritanceReversed.cs"],
+            [("Main.generated.cs", "MainWithInheritanceReversed.generated.cs")]
+        );
+    }
 }

--- a/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/MainWithInheritanceReversed.generated.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/GeneratedSources/MainWithInheritanceReversed.generated.cs
@@ -34,11 +34,9 @@ internal static class ClassDBExtensions
         {
             return;
         }
-        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.BaseType>(global::NS.BaseType.BindMembers);
-        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.DerivedType>(global::NS.DerivedType.BindMembers);
-        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.DerivedType2>(global::NS.DerivedType2.BindMembers);
-        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.DerivedType3>(global::NS.DerivedType3.BindMembers);
-        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.HighlyDerivedType>(global::NS.HighlyDerivedType.BindMembers);
+        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.Mob>(global::NS.Mob.BindMembers);
+        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.Enemy>(global::NS.Enemy.BindMembers);
+        global::Godot.Bridge.GodotRegistry.RegisterRuntimeClass<global::NS.Bat>(global::NS.Bat.BindMembers);
     }
     internal static void DeinitializeUserTypes(global::Godot.Bridge.InitializationLevel level)
     {

--- a/tests/Godot.SourceGeneration.Tests/TestData/Sources/NodesWithInheritanceReversed.cs
+++ b/tests/Godot.SourceGeneration.Tests/TestData/Sources/NodesWithInheritanceReversed.cs
@@ -1,0 +1,22 @@
+using Godot;
+using Godot.Bridge;
+
+namespace NS;
+
+[GodotClass]
+public partial class Bat : Enemy
+{
+    public new static void BindMembers(ClassRegistrationContext context) { }
+}
+
+[GodotClass]
+public partial class Enemy : Mob
+{
+    public new static void BindMembers(ClassRegistrationContext context) { }
+}
+
+[GodotClass]
+public partial class Mob : Node
+{
+    public static void BindMembers(ClassRegistrationContext context) { }
+}


### PR DESCRIPTION
## Problem

The entry-point generator orders registered `[GodotClass]` types so that **base classes register before derived classes** and this is necessary because registration is eager: `GodotRegistry.RegisterClassCore` calls `classdb_register_extension_class…` with the parent's name immediately, so if a class is registered before its base, the engine rejects it (unknown parent) and **the whole C# extension fails to load.**

But the ordering in `EntryPointGenerator` was not a topological sort, but a declaration-order-dependent heuristic: it built the type map *incrementally* inside the same loop and only accumulated a "derived count" for base types **already seen**, then `OrderByDescending`'d that count. So the emitted order depends on source/file order.

Concrete failure: three classes `Bat : Enemy`, `Enemy : Mob`, `Mob : Node` declared derived-first (e.g. alphabetical file order) are emitted as `Enemy, Mob, Bat` -> `Enemy` before its base `Mob` -> the engine rejects `Enemy` -> the extension doesn't load. Nothing about the code is wrong, only the file naming.

## Fix

Replace the heuristic with a real topological order: build the complete `name -> spec` map first, then order by each type's **transitive registered-ancestor depth** with a stable sort:

```csharp
int GetRegisteredAncestorDepth(GodotRegistrationSpec spec)
{
    int depth = 0;
    string baseTypeName = spec.FullyQualifiedBaseSymbolName;
    while (specByTypeName.TryGetValue(baseTypeName, out var baseSpec))
    {
        depth++;
        baseTypeName = baseSpec.FullyQualifiedBaseSymbolName;
    }
    return depth;
}
return specs.OrderBy(GetRegisteredAncestorDepth).ToImmutableArray();
```

A base type always has a strictly lower depth than any type deriving from it, so base classes always come first; `OrderBy` is stable, so unrelated (equal-depth) classes keep their declaration order. (C# forbids inheritance cycles, so the walk always terminates.)

## Verification

- **New regression test** (`EntryPointGeneratorTests`): an inheritance chain declared derived-first. **Fail-before:** the old generator emitted `Enemy, Mob, Bat` (derived before base). **Pass-after:** `Mob, Enemy, Bat`.
- The existing `MainWithInheritance` snapshot's order changed slightly (a sibling moved so equal-depth types are now in declaration order) — still every base before its derived; regenerated to match.
- `Godot.SourceGeneration.Tests`: 22/22.

I found this issue while auditing the source generator for adoption-blocking bugs and this issue was not previously filed.
