### PR TITLE
Fix parameter pointer aliasing in class member registration

### DIFF
--- a/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindMethod.cs
+++ b/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindMethod.cs
@@ -36,96 +36,78 @@ partial class ClassRegistrationContext
 
         _registerBindingActions.Enqueue(() =>
         {
+            int parameterCount = methodDefinition.Parameters.Count;
+
             // Convert managed method info to the internal unmanaged type.
+            // The engine reads the pointers stored in 'methodInfoNative' when the method
+            // is registered at the end, so every value that is pointed to must be kept
+            // alive, in its own stack slot, until then. Block or loop scoped locals must
+            // not be used for these values because their stack slots could be reused,
+            // leaving dangling or aliased pointers behind.
             var methodInfoNative = new GDExtensionClassMethodInfo();
+
+            NativeGodotStringName nameNative = methodDefinition.Name.NativeValue.DangerousSelfRef;
+            methodInfoNative.name = &nameNative;
+
+            var methodFlags = GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAGS_DEFAULT;
+            if (methodDefinition.IsStatic)
             {
-                NativeGodotStringName nameNative = methodDefinition.Name.NativeValue.DangerousSelfRef;
-                methodInfoNative.name = &nameNative;
-
-                var methodFlags = GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAGS_DEFAULT;
-                if (methodDefinition.IsStatic)
-                {
-                    methodFlags |= GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAG_STATIC;
-                }
-                methodInfoNative.method_flags = (uint)methodFlags;
-
-                // Return
-
-                if (methodDefinition.Return is not null)
-                {
-                    // Convert managed property info to the internal unmanaged type.
-                    GDExtensionPropertyInfo ret;
-                    {
-                        NativeGodotStringName returnNameNative = methodDefinition.Return.Name.NativeValue.DangerousSelfRef;
-                        NativeGodotStringName returnClassNameNative = (methodDefinition.Return.ClassName?.NativeValue ?? default).DangerousSelfRef;
-                        NativeGodotString hintStringNative = NativeGodotString.Create(methodDefinition.Return.HintString);
-
-                        ret = new GDExtensionPropertyInfo()
-                        {
-                            type = (GDExtensionVariantType)methodDefinition.Return.Type,
-                            name = &returnNameNative,
-
-                            hint = (uint)methodDefinition.Return.Hint,
-                            hint_string = &hintStringNative,
-                            class_name = &returnClassNameNative,
-                            usage = (uint)methodDefinition.Return.Usage,
-                        };
-                    }
-
-                    methodInfoNative.has_return_value = true;
-                    methodInfoNative.return_value_info = &ret;
-                    methodInfoNative.return_value_metadata = (GDExtensionClassMethodArgumentMetadata)methodDefinition.Return.TypeMetadata;
-                }
-
-                // Parameters
-
-                var args = stackalloc GDExtensionPropertyInfo[methodDefinition.Parameters.Count];
-                var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[methodDefinition.Parameters.Count];
-                var argsDefaultValues = stackalloc NativeGodotVariant*[methodDefinition.Parameters.Count];
-
-                uint optionalParameterCount = 0;
-                for (int i = 0; i < methodDefinition.Parameters.Count; i++)
-                {
-                    var parameter = methodDefinition.Parameters[i];
-
-                    if (optionalParameterCount > 0 && parameter.DefaultValue is null)
-                    {
-                        throw new InvalidOperationException(SR.InvalidOperation_MethodOptionalParametersMustAppearAfterRequiredParameters);
-                    }
-
-                    if (parameter.DefaultValue is not null)
-                    {
-                        NativeGodotVariant defaultValue = parameter.DefaultValue.Value.NativeValue.DangerousSelfRef;
-                        argsDefaultValues[optionalParameterCount++] = &defaultValue;
-                    }
-
-                    // Convert managed parameter info to the internal unmanaged type.
-                    {
-                        NativeGodotStringName parameterNameNative = parameter.Name.NativeValue.DangerousSelfRef;
-                        NativeGodotStringName parameterClassNameNative = (parameter.ClassName?.NativeValue ?? default).DangerousSelfRef;
-                        NativeGodotString hintStringNative = NativeGodotString.Create(parameter.HintString);
-
-                        args[i] = new GDExtensionPropertyInfo()
-                        {
-                            type = (GDExtensionVariantType)parameter.Type,
-                            name = &parameterNameNative,
-
-                            hint = (uint)parameter.Hint,
-                            hint_string = &hintStringNative,
-                            class_name = &parameterClassNameNative,
-                            usage = (uint)parameter.Usage,
-                        };
-                    }
-                    argsMetadata[i] = (GDExtensionClassMethodArgumentMetadata)parameter.TypeMetadata;
-                }
-
-                methodInfoNative.argument_count = (uint)methodDefinition.Parameters.Count;
-                methodInfoNative.arguments_info = args;
-                methodInfoNative.arguments_metadata = argsMetadata;
-
-                methodInfoNative.default_argument_count = optionalParameterCount;
-                methodInfoNative.default_arguments = argsDefaultValues;
+                methodFlags |= GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAG_STATIC;
             }
+            methodInfoNative.method_flags = (uint)methodFlags;
+
+            // Return
+
+            GDExtensionPropertyInfo returnInfoNative = default;
+            NativeGodotStringName returnNameNative = default;
+            NativeGodotStringName returnClassNameNative = default;
+            NativeGodotString returnHintStringNative = default;
+
+            if (methodDefinition.Return is not null)
+            {
+                // Convert managed property info to the internal unmanaged type.
+                returnNameNative = methodDefinition.Return.Name.NativeValue.DangerousSelfRef;
+                returnClassNameNative = (methodDefinition.Return.ClassName?.NativeValue ?? default).DangerousSelfRef;
+                returnHintStringNative = NativeGodotString.Create(methodDefinition.Return.HintString);
+
+                returnInfoNative = new GDExtensionPropertyInfo()
+                {
+                    type = (GDExtensionVariantType)methodDefinition.Return.Type,
+                    name = &returnNameNative,
+
+                    hint = (uint)methodDefinition.Return.Hint,
+                    hint_string = &returnHintStringNative,
+                    class_name = &returnClassNameNative,
+                    usage = (uint)methodDefinition.Return.Usage,
+                };
+
+                methodInfoNative.has_return_value = true;
+                methodInfoNative.return_value_info = &returnInfoNative;
+                methodInfoNative.return_value_metadata = (GDExtensionClassMethodArgumentMetadata)methodDefinition.Return.TypeMetadata;
+            }
+
+            // Parameters
+
+            var args = stackalloc GDExtensionPropertyInfo[parameterCount];
+            var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[parameterCount];
+            var argsDefaultValues = stackalloc NativeGodotVariant*[parameterCount];
+
+            // Parallel buffers with one slot for each parameter, so the pointers stored
+            // in 'args' and 'argsDefaultValues' remain distinct and valid until the
+            // method is registered below.
+            var argsNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsHintStringsNative = stackalloc NativeGodotString[parameterCount];
+            var argsDefaultValuesNative = stackalloc NativeGodotVariant[parameterCount];
+
+            uint optionalParameterCount = ConvertParameterInfosToNative(methodDefinition.Parameters, args, argsMetadata, argsDefaultValues, argsNamesNative, argsClassNamesNative, argsHintStringsNative, argsDefaultValuesNative);
+
+            methodInfoNative.argument_count = (uint)parameterCount;
+            methodInfoNative.arguments_info = args;
+            methodInfoNative.arguments_metadata = argsMetadata;
+
+            methodInfoNative.default_argument_count = optionalParameterCount;
+            methodInfoNative.default_arguments = argsDefaultValues;
 
             var methodGCHandle = new GCHandle<MethodDefinition>(methodDefinition);
             _registeredMethodHandles.Add(methodDefinition.Name, methodGCHandle);
@@ -138,7 +120,73 @@ partial class ClassRegistrationContext
             NativeGodotStringName classNameNative = ClassName.NativeValue.DangerousSelfRef;
 
             GodotBridge.GDExtensionInterface.classdb_register_extension_class_method(GodotBridge.LibraryPtr, &classNameNative, &methodInfoNative);
+
+            // The engine copies the data when the method is registered, so the native
+            // strings created for the conversion can be destroyed now.
+            returnHintStringNative.Dispose();
+            for (int i = 0; i < parameterCount; i++)
+            {
+                argsHintStringsNative[i].Dispose();
+            }
         });
+    }
+
+    /// <summary>
+    /// Converts the managed parameter definitions to the internal unmanaged type,
+    /// filling the buffers provided by the caller. All the buffers must have one
+    /// slot for each parameter and must be pinned or stack allocated because
+    /// <paramref name="args"/> and <paramref name="argsDefaultValues"/> store
+    /// pointers to the slots of the other buffers, which must remain valid for
+    /// as long as the converted parameter information is in use.
+    /// </summary>
+    /// <returns>The number of optional parameters (i.e.: parameters with a default value).</returns>
+    internal static unsafe uint ConvertParameterInfosToNative(List<ParameterDefinition> parameters, GDExtensionPropertyInfo* args, GDExtensionClassMethodArgumentMetadata* argsMetadata, NativeGodotVariant** argsDefaultValues, NativeGodotStringName* argsNamesNative, NativeGodotStringName* argsClassNamesNative, NativeGodotString* argsHintStringsNative, NativeGodotVariant* argsDefaultValuesNative)
+    {
+        // Validate the parameter ordering up front, before any native strings are
+        // created, so an invalid definition throws without leaking them.
+        bool seenOptionalParameter = false;
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            if (parameters[i].DefaultValue is not null)
+            {
+                seenOptionalParameter = true;
+            }
+            else if (seenOptionalParameter)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_MethodOptionalParametersMustAppearAfterRequiredParameters);
+            }
+        }
+
+        uint optionalParameterCount = 0;
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var parameter = parameters[i];
+
+            if (parameter.DefaultValue is not null)
+            {
+                argsDefaultValuesNative[i] = parameter.DefaultValue.Value.NativeValue.DangerousSelfRef;
+                argsDefaultValues[optionalParameterCount++] = &argsDefaultValuesNative[i];
+            }
+
+            // Convert managed parameter info to the internal unmanaged type.
+            argsNamesNative[i] = parameter.Name.NativeValue.DangerousSelfRef;
+            argsClassNamesNative[i] = (parameter.ClassName?.NativeValue ?? default).DangerousSelfRef;
+            argsHintStringsNative[i] = NativeGodotString.Create(parameter.HintString);
+
+            args[i] = new GDExtensionPropertyInfo()
+            {
+                type = (GDExtensionVariantType)parameter.Type,
+                name = &argsNamesNative[i],
+
+                hint = (uint)parameter.Hint,
+                hint_string = &argsHintStringsNative[i],
+                class_name = &argsClassNamesNative[i],
+                usage = (uint)parameter.Usage,
+            };
+            argsMetadata[i] = (GDExtensionClassMethodArgumentMetadata)parameter.TypeMetadata;
+        }
+
+        return optionalParameterCount;
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindSignal.cs
+++ b/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindSignal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
 namespace Godot.Bridge;
@@ -29,38 +30,96 @@ partial class ClassRegistrationContext
 
         _registerBindingActions.Enqueue(() =>
         {
+            int parameterCount = signalDefinition.Parameters.Count;
+
             // Convert managed signal info to the internal unmanaged type.
-            Span<GDExtensionPropertyInfo> parameters = signalDefinition.Parameters.Count <= ParameterSpanThreshold
-                ? stackalloc GDExtensionPropertyInfo[ParameterSpanThreshold].Slice(0, signalDefinition.Parameters.Count)
-                : new GDExtensionPropertyInfo[signalDefinition.Parameters.Count];
-            for (int i = 0; i < parameters.Length; i++)
+            Span<GDExtensionPropertyInfo> parameters = parameterCount <= ParameterSpanThreshold
+                ? stackalloc GDExtensionPropertyInfo[ParameterSpanThreshold].Slice(0, parameterCount)
+                : new GDExtensionPropertyInfo[parameterCount];
+
+            // Parallel buffers with one slot for each parameter, so the pointers stored
+            // in 'parameters' remain distinct and valid until the signal is registered
+            // below. Loop scoped locals must not be used for these values because their
+            // stack slots would be reused by every iteration, leaving all the pointers
+            // aliasing the same address. The slot types are ref structs, so the buffers
+            // can't use managed arrays like 'parameters' does; when the parameter count
+            // exceeds 'ParameterSpanThreshold' allocate the buffers from native memory
+            // instead, which doesn't require pinning.
+            var parameterNamesStackBuffer = stackalloc NativeGodotStringName[ParameterSpanThreshold];
+            var parameterClassNamesStackBuffer = stackalloc NativeGodotStringName[ParameterSpanThreshold];
+            var parameterHintStringsStackBuffer = stackalloc NativeGodotString[ParameterSpanThreshold];
+
+            NativeGodotStringName* parameterNamesNative = parameterNamesStackBuffer;
+            NativeGodotStringName* parameterClassNamesNative = parameterClassNamesStackBuffer;
+            NativeGodotString* parameterHintStringsNative = parameterHintStringsStackBuffer;
+
+            if (parameterCount > ParameterSpanThreshold)
             {
-                var parameterDefinition = signalDefinition.Parameters[i];
-
-                NativeGodotStringName parameterNameNative = parameterDefinition.Name.NativeValue.DangerousSelfRef;
-                NativeGodotStringName parameterClassNameNative = (parameterDefinition.ClassName?.NativeValue ?? default).DangerousSelfRef;
-                NativeGodotString hintStringNative = NativeGodotString.Create(parameterDefinition.HintString);
-
-                parameters[i] = new GDExtensionPropertyInfo()
-                {
-                    type = (GDExtensionVariantType)parameterDefinition.Type,
-                    name = &parameterNameNative,
-
-                    hint = (uint)parameterDefinition.Hint,
-                    hint_string = &hintStringNative,
-                    class_name = &parameterClassNameNative,
-                    usage = (uint)parameterDefinition.Usage,
-                };
+                parameterNamesNative = (NativeGodotStringName*)NativeMemory.Alloc((nuint)parameterCount, (nuint)sizeof(NativeGodotStringName));
+                parameterClassNamesNative = (NativeGodotStringName*)NativeMemory.Alloc((nuint)parameterCount, (nuint)sizeof(NativeGodotStringName));
+                parameterHintStringsNative = (NativeGodotString*)NativeMemory.Alloc((nuint)parameterCount, (nuint)sizeof(NativeGodotString));
             }
 
-            NativeGodotStringName signalNameNative = signalDefinition.Name.NativeValue.DangerousSelfRef;
-
-            NativeGodotStringName classNameNative = ClassName.NativeValue.DangerousSelfRef;
-
-            fixed (GDExtensionPropertyInfo* parametersPtr = parameters)
+            try
             {
-                GodotBridge.GDExtensionInterface.classdb_register_extension_class_signal(GodotBridge.LibraryPtr, &classNameNative, &signalNameNative, parametersPtr, parameters.Length);
+                fixed (GDExtensionPropertyInfo* parametersPtr = parameters)
+                {
+                    ConvertSignalParameterInfosToNative(signalDefinition.Parameters, parametersPtr, parameterNamesNative, parameterClassNamesNative, parameterHintStringsNative);
+
+                    NativeGodotStringName signalNameNative = signalDefinition.Name.NativeValue.DangerousSelfRef;
+
+                    NativeGodotStringName classNameNative = ClassName.NativeValue.DangerousSelfRef;
+
+                    GodotBridge.GDExtensionInterface.classdb_register_extension_class_signal(GodotBridge.LibraryPtr, &classNameNative, &signalNameNative, parametersPtr, parameterCount);
+
+                    // The engine copies the data when the signal is registered, so the native
+                    // strings created for the conversion can be destroyed now.
+                    for (int i = 0; i < parameterCount; i++)
+                    {
+                        parameterHintStringsNative[i].Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (parameterCount > ParameterSpanThreshold)
+                {
+                    NativeMemory.Free(parameterNamesNative);
+                    NativeMemory.Free(parameterClassNamesNative);
+                    NativeMemory.Free(parameterHintStringsNative);
+                }
             }
         });
+    }
+
+    /// <summary>
+    /// Converts the managed parameter definitions to the internal unmanaged type,
+    /// filling the buffers provided by the caller. All the buffers must have one
+    /// slot for each parameter and must be pinned or stack allocated because
+    /// <paramref name="parameters"/> stores pointers to the slots of the other
+    /// buffers, which must remain valid for as long as the converted parameter
+    /// information is in use.
+    /// </summary>
+    internal static unsafe void ConvertSignalParameterInfosToNative(List<ParameterDefinition> parameterDefinitions, GDExtensionPropertyInfo* parameters, NativeGodotStringName* parameterNamesNative, NativeGodotStringName* parameterClassNamesNative, NativeGodotString* parameterHintStringsNative)
+    {
+        for (int i = 0; i < parameterDefinitions.Count; i++)
+        {
+            var parameterDefinition = parameterDefinitions[i];
+
+            parameterNamesNative[i] = parameterDefinition.Name.NativeValue.DangerousSelfRef;
+            parameterClassNamesNative[i] = (parameterDefinition.ClassName?.NativeValue ?? default).DangerousSelfRef;
+            parameterHintStringsNative[i] = NativeGodotString.Create(parameterDefinition.HintString);
+
+            parameters[i] = new GDExtensionPropertyInfo()
+            {
+                type = (GDExtensionVariantType)parameterDefinition.Type,
+                name = &parameterNamesNative[i],
+
+                hint = (uint)parameterDefinition.Hint,
+                hint_string = &parameterHintStringsNative[i],
+                class_name = &parameterClassNamesNative[i],
+                usage = (uint)parameterDefinition.Usage,
+            };
+        }
     }
 }

--- a/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindVirtualMethod.cs
+++ b/src/Godot.Bindings/Bridge/Registration/ClassRegistrationContext.BindVirtualMethod.cs
@@ -25,92 +25,84 @@ partial class ClassRegistrationContext
 
         _registerBindingActions.Enqueue(() =>
         {
+            int parameterCount = methodDefinition.Parameters.Count;
+
             // Convert managed method info to the internal unmanaged type.
+            // The engine reads the pointers stored in 'methodInfoNative' when the method
+            // is registered at the end, so every value that is pointed to must be kept
+            // alive, in its own stack slot, until then. Block or loop scoped locals must
+            // not be used for these values because their stack slots could be reused,
+            // leaving dangling or aliased pointers behind.
             var methodInfoNative = new GDExtensionClassVirtualMethodInfo();
+
+            NativeGodotStringName nameNative = methodDefinition.Name.NativeValue.DangerousSelfRef;
+            methodInfoNative.name = &nameNative;
+
+            var methodFlags = GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAGS_DEFAULT | GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAG_VIRTUAL;
+            methodInfoNative.method_flags = (uint)methodFlags;
+
+            // Return
+
+            GDExtensionPropertyInfo returnInfoNative = default;
+            NativeGodotStringName returnNameNative = default;
+            NativeGodotStringName returnClassNameNative = default;
+            NativeGodotString returnHintStringNative = default;
+
+            if (methodDefinition.Return is not null)
             {
-                NativeGodotStringName nameNative = methodDefinition.Name.NativeValue.DangerousSelfRef;
-                methodInfoNative.name = &nameNative;
+                // Convert managed property info to the internal unmanaged type.
+                returnNameNative = methodDefinition.Return.Name.NativeValue.DangerousSelfRef;
+                returnClassNameNative = (methodDefinition.Return.ClassName?.NativeValue ?? default).DangerousSelfRef;
+                returnHintStringNative = NativeGodotString.Create(methodDefinition.Return.HintString);
 
-                var methodFlags = GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAGS_DEFAULT | GDExtensionClassMethodFlags.GDEXTENSION_METHOD_FLAG_VIRTUAL;
-                methodInfoNative.method_flags = (uint)methodFlags;
-
-                // Return
-
-                if (methodDefinition.Return is not null)
+                returnInfoNative = new GDExtensionPropertyInfo()
                 {
-                    // Convert managed property info to the internal unmanaged type.
-                    GDExtensionPropertyInfo ret;
-                    {
-                        NativeGodotStringName returnNameNative = methodDefinition.Return.Name.NativeValue.DangerousSelfRef;
-                        NativeGodotStringName returnClassNameNative = (methodDefinition.Return.ClassName?.NativeValue ?? default).DangerousSelfRef;
-                        NativeGodotString hintStringNative = NativeGodotString.Create(methodDefinition.Return.HintString);
+                    type = (GDExtensionVariantType)methodDefinition.Return.Type,
+                    name = &returnNameNative,
 
-                        ret = new GDExtensionPropertyInfo()
-                        {
-                            type = (GDExtensionVariantType)methodDefinition.Return.Type,
-                            name = &returnNameNative,
+                    hint = (uint)methodDefinition.Return.Hint,
+                    hint_string = &returnHintStringNative,
+                    class_name = &returnClassNameNative,
+                    usage = (uint)methodDefinition.Return.Usage,
+                };
 
-                            hint = (uint)methodDefinition.Return.Hint,
-                            hint_string = &hintStringNative,
-                            class_name = &returnClassNameNative,
-                            usage = (uint)methodDefinition.Return.Usage,
-                        };
-                    }
-
-                    methodInfoNative.return_value = ret;
-                    methodInfoNative.return_value_metadata = (GDExtensionClassMethodArgumentMetadata)methodDefinition.Return.TypeMetadata;
-                }
-
-                // Parameters
-
-                var args = stackalloc GDExtensionPropertyInfo[methodDefinition.Parameters.Count];
-                var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[methodDefinition.Parameters.Count];
-                var argsDefaultValues = stackalloc NativeGodotVariant*[methodDefinition.Parameters.Count];
-
-                uint optionalParameterCount = 0;
-                for (int i = 0; i < methodDefinition.Parameters.Count; i++)
-                {
-                    var parameter = methodDefinition.Parameters[i];
-
-                    if (optionalParameterCount > 0 && parameter.DefaultValue is null)
-                    {
-                        throw new InvalidOperationException(SR.InvalidOperation_MethodOptionalParametersMustAppearAfterRequiredParameters);
-                    }
-
-                    if (parameter.DefaultValue is not null)
-                    {
-                        NativeGodotVariant defaultValue = parameter.DefaultValue.Value.NativeValue.DangerousSelfRef;
-                        argsDefaultValues[optionalParameterCount++] = &defaultValue;
-                    }
-
-                    // Convert managed parameter info to the internal unmanaged type.
-                    {
-                        NativeGodotStringName parameterNameNative = parameter.Name.NativeValue.DangerousSelfRef;
-                        NativeGodotStringName parameterClassNameNative = (parameter.ClassName?.NativeValue ?? default).DangerousSelfRef;
-                        NativeGodotString hintStringNative = NativeGodotString.Create(parameter.HintString);
-
-                        args[i] = new GDExtensionPropertyInfo()
-                        {
-                            type = (GDExtensionVariantType)parameter.Type,
-                            name = &parameterNameNative,
-
-                            hint = (uint)parameter.Hint,
-                            hint_string = &hintStringNative,
-                            class_name = &parameterClassNameNative,
-                            usage = (uint)parameter.Usage,
-                        };
-                    }
-                    argsMetadata[i] = (GDExtensionClassMethodArgumentMetadata)parameter.TypeMetadata;
-                }
-
-                methodInfoNative.argument_count = (uint)methodDefinition.Parameters.Count;
-                methodInfoNative.arguments = args;
-                methodInfoNative.arguments_metadata = argsMetadata;
+                methodInfoNative.return_value = returnInfoNative;
+                methodInfoNative.return_value_metadata = (GDExtensionClassMethodArgumentMetadata)methodDefinition.Return.TypeMetadata;
             }
+
+            // Parameters
+
+            var args = stackalloc GDExtensionPropertyInfo[parameterCount];
+            var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[parameterCount];
+            var argsDefaultValues = stackalloc NativeGodotVariant*[parameterCount];
+
+            // Parallel buffers with one slot for each parameter, so the pointers stored
+            // in 'args' and 'argsDefaultValues' remain distinct and valid until the
+            // method is registered below.
+            var argsNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsHintStringsNative = stackalloc NativeGodotString[parameterCount];
+            var argsDefaultValuesNative = stackalloc NativeGodotVariant[parameterCount];
+
+            // Virtual method registration doesn't include default arguments, so the
+            // optional parameter count and the default value buffers are unused.
+            _ = ConvertParameterInfosToNative(methodDefinition.Parameters, args, argsMetadata, argsDefaultValues, argsNamesNative, argsClassNamesNative, argsHintStringsNative, argsDefaultValuesNative);
+
+            methodInfoNative.argument_count = (uint)parameterCount;
+            methodInfoNative.arguments = args;
+            methodInfoNative.arguments_metadata = argsMetadata;
 
             NativeGodotStringName classNameNative = ClassName.NativeValue.DangerousSelfRef;
 
             GodotBridge.GDExtensionInterface.classdb_register_extension_class_virtual_method(GodotBridge.LibraryPtr, &classNameNative, &methodInfoNative);
+
+            // The engine copies the data when the method is registered, so the native
+            // strings created for the conversion can be destroyed now.
+            returnHintStringNative.Dispose();
+            for (int i = 0; i < parameterCount; i++)
+            {
+                argsHintStringsNative[i].Dispose();
+            }
         });
     }
 }

--- a/tests/Godot.Bindings.Tests/Bridge/ClassRegistrationContextConversionTests.cs
+++ b/tests/Godot.Bindings.Tests/Bridge/ClassRegistrationContextConversionTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using Godot.Bridge;
+using Godot.NativeInterop;
+
+namespace Godot.Bindings.Tests;
+
+// These tests run without a Godot engine host, so every GDExtension interface
+// function is a null function pointer and can't be called. Non-empty StringName
+// and String values can't be created in this environment because they require
+// interop calls, so the definitions below use empty names and null hint strings.
+// The assertions target the address stored in each converted slot, which is
+// exactly what the parameter aliasing bug corrupted (every parameter's pointers
+// ended up aliasing the same reused stack slot, so all parameters registered
+// with the last parameter's data), and the default values, which can be created
+// without interop for the Bool, Int and Float variant types.
+public class ClassRegistrationContextConversionTests
+{
+    [Fact]
+    public unsafe void ConvertParameterInfosToNativeGivesEachParameterItsOwnSlot()
+    {
+        var parameters = new List<ParameterDefinition>
+        {
+            new ParameterDefinition(new StringName(""), VariantType.Int, VariantTypeMetadata.Int32, 1L),
+            new ParameterDefinition(new StringName(""), VariantType.Float, VariantTypeMetadata.Double, 2.5),
+            new ParameterDefinition(new StringName(""), VariantType.Bool, VariantTypeMetadata.None, true),
+        };
+        int parameterCount = parameters.Count;
+
+        var args = stackalloc GDExtensionPropertyInfo[parameterCount];
+        var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[parameterCount];
+        var argsDefaultValues = stackalloc NativeGodotVariant*[parameterCount];
+        var argsNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var argsClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var argsHintStringsNative = stackalloc NativeGodotString[parameterCount];
+        var argsDefaultValuesNative = stackalloc NativeGodotVariant[parameterCount];
+
+        uint optionalParameterCount = ClassRegistrationContext.ConvertParameterInfosToNative(parameters, args, argsMetadata, argsDefaultValues, argsNamesNative, argsClassNamesNative, argsHintStringsNative, argsDefaultValuesNative);
+
+        Assert.Equal(3u, optionalParameterCount);
+
+        for (int i = 0; i < parameterCount; i++)
+        {
+            // Every parameter's pointers must point to that parameter's own slot.
+            Assert.Equal((nint)(&argsNamesNative[i]), (nint)args[i].name);
+            Assert.Equal((nint)(&argsClassNamesNative[i]), (nint)args[i].class_name);
+            Assert.Equal((nint)(&argsHintStringsNative[i]), (nint)args[i].hint_string);
+            Assert.Equal((nint)(&argsDefaultValuesNative[i]), (nint)argsDefaultValues[i]);
+
+            Assert.Equal((GDExtensionVariantType)parameters[i].Type, args[i].type);
+            Assert.Equal((GDExtensionClassMethodArgumentMetadata)parameters[i].TypeMetadata, argsMetadata[i]);
+
+            for (int j = i + 1; j < parameterCount; j++)
+            {
+                // The pointers of different parameters must be pairwise distinct.
+                Assert.NotEqual((nint)args[i].name, (nint)args[j].name);
+                Assert.NotEqual((nint)args[i].class_name, (nint)args[j].class_name);
+                Assert.NotEqual((nint)args[i].hint_string, (nint)args[j].hint_string);
+                Assert.NotEqual((nint)argsDefaultValues[i], (nint)argsDefaultValues[j]);
+            }
+        }
+
+        // Each default value must dereference to the value of the parameter it
+        // belongs to; the aliasing bug collapsed all the default values into the
+        // last parameter's value.
+        Assert.Equal(VariantType.Int, argsDefaultValues[0]->Type);
+        Assert.Equal(1L, argsDefaultValues[0]->Int);
+        Assert.Equal(VariantType.Float, argsDefaultValues[1]->Type);
+        Assert.Equal(2.5, argsDefaultValues[1]->Float);
+        Assert.Equal(VariantType.Bool, argsDefaultValues[2]->Type);
+        Assert.True(argsDefaultValues[2]->Bool);
+    }
+
+    [Fact]
+    public unsafe void ConvertParameterInfosToNativeThrowsWhenRequiredParameterFollowsOptional()
+    {
+        var parameters = new List<ParameterDefinition>
+        {
+            new ParameterDefinition(new StringName(""), VariantType.Int, VariantTypeMetadata.None, 1L),
+            new ParameterDefinition(new StringName(""), VariantType.Int),
+        };
+
+        Assert.Throws<InvalidOperationException>(() => Convert(parameters));
+
+        static unsafe void Convert(List<ParameterDefinition> parameters)
+        {
+            int parameterCount = parameters.Count;
+
+            var args = stackalloc GDExtensionPropertyInfo[parameterCount];
+            var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[parameterCount];
+            var argsDefaultValues = stackalloc NativeGodotVariant*[parameterCount];
+            var argsNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+            var argsHintStringsNative = stackalloc NativeGodotString[parameterCount];
+            var argsDefaultValuesNative = stackalloc NativeGodotVariant[parameterCount];
+
+            ClassRegistrationContext.ConvertParameterInfosToNative(parameters, args, argsMetadata, argsDefaultValues, argsNamesNative, argsClassNamesNative, argsHintStringsNative, argsDefaultValuesNative);
+        }
+    }
+
+    // Pins the compaction of default values when the optional parameters trail a
+    // required parameter: 'argsDefaultValues' must contain one entry per optional
+    // parameter, in order, each pointing at that parameter's own slot in
+    // 'argsDefaultValuesNative' (indexed by parameter index, not by optional
+    // index). A naive 'argsDefaultValues[i]' write instead of
+    // 'argsDefaultValues[optionalParameterCount++]' would fail this test.
+    [Fact]
+    public unsafe void ConvertParameterInfosToNativeCompactsDefaultsForTrailingOptionalParameters()
+    {
+        var parameters = new List<ParameterDefinition>
+        {
+            new ParameterDefinition(new StringName(""), VariantType.Int),
+            new ParameterDefinition(new StringName(""), VariantType.Int, VariantTypeMetadata.None, 10L),
+            new ParameterDefinition(new StringName(""), VariantType.Bool, VariantTypeMetadata.None, true),
+        };
+        int parameterCount = parameters.Count;
+
+        var args = stackalloc GDExtensionPropertyInfo[parameterCount];
+        var argsMetadata = stackalloc GDExtensionClassMethodArgumentMetadata[parameterCount];
+        var argsDefaultValues = stackalloc NativeGodotVariant*[parameterCount];
+        var argsNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var argsClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var argsHintStringsNative = stackalloc NativeGodotString[parameterCount];
+        var argsDefaultValuesNative = stackalloc NativeGodotVariant[parameterCount];
+
+        uint optionalParameterCount = ClassRegistrationContext.ConvertParameterInfosToNative(parameters, args, argsMetadata, argsDefaultValues, argsNamesNative, argsClassNamesNative, argsHintStringsNative, argsDefaultValuesNative);
+
+        Assert.Equal(2u, optionalParameterCount);
+
+        // The compacted default value pointers must map to the trailing optional
+        // parameters' own slots (parameter indices 1 and 2), not to the first
+        // slots of 'argsDefaultValuesNative'.
+        Assert.Equal((nint)(&argsDefaultValuesNative[1]), (nint)argsDefaultValues[0]);
+        Assert.Equal((nint)(&argsDefaultValuesNative[2]), (nint)argsDefaultValues[1]);
+
+        Assert.Equal(VariantType.Int, argsDefaultValues[0]->Type);
+        Assert.Equal(10L, argsDefaultValues[0]->Int);
+        Assert.Equal(VariantType.Bool, argsDefaultValues[1]->Type);
+        Assert.True(argsDefaultValues[1]->Bool);
+
+        // Sanity: the parameter name pointers must still be pairwise distinct.
+        for (int i = 0; i < parameterCount; i++)
+        {
+            for (int j = i + 1; j < parameterCount; j++)
+            {
+                Assert.NotEqual((nint)args[i].name, (nint)args[j].name);
+            }
+        }
+    }
+
+    [Fact]
+    public unsafe void ConvertSignalParameterInfosToNativeGivesEachParameterItsOwnSlot()
+    {
+        var parameters = new List<ParameterDefinition>
+        {
+            new ParameterDefinition(new StringName(""), VariantType.Int, VariantTypeMetadata.Int32),
+            new ParameterDefinition(new StringName(""), VariantType.Float, VariantTypeMetadata.Double),
+            new ParameterDefinition(new StringName(""), VariantType.Bool),
+        };
+        int parameterCount = parameters.Count;
+
+        var parametersNative = stackalloc GDExtensionPropertyInfo[parameterCount];
+        var parameterNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var parameterClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var parameterHintStringsNative = stackalloc NativeGodotString[parameterCount];
+
+        ClassRegistrationContext.ConvertSignalParameterInfosToNative(parameters, parametersNative, parameterNamesNative, parameterClassNamesNative, parameterHintStringsNative);
+
+        for (int i = 0; i < parameterCount; i++)
+        {
+            // Every parameter's pointers must point to that parameter's own slot.
+            Assert.Equal((nint)(&parameterNamesNative[i]), (nint)parametersNative[i].name);
+            Assert.Equal((nint)(&parameterClassNamesNative[i]), (nint)parametersNative[i].class_name);
+            Assert.Equal((nint)(&parameterHintStringsNative[i]), (nint)parametersNative[i].hint_string);
+
+            Assert.Equal((GDExtensionVariantType)parameters[i].Type, parametersNative[i].type);
+
+            for (int j = i + 1; j < parameterCount; j++)
+            {
+                // The pointers of different parameters must be pairwise distinct.
+                Assert.NotEqual((nint)parametersNative[i].name, (nint)parametersNative[j].name);
+                Assert.NotEqual((nint)parametersNative[i].class_name, (nint)parametersNative[j].class_name);
+                Assert.NotEqual((nint)parametersNative[i].hint_string, (nint)parametersNative[j].hint_string);
+            }
+        }
+    }
+
+    // Exercises the conversion helper with a parameter count above
+    // 'ParameterSpanThreshold' (8). BindSignal's actual NativeMemory.Alloc/Free
+    // heap branch calls 'classdb_register_extension_class_signal' and therefore
+    // requires a running Godot editor, so it is covered by integration tests,
+    // not here.
+    [Fact]
+    public unsafe void ConvertSignalParameterInfosToNativeWithManyParametersGivesEachItsOwnSlot()
+    {
+        var parameters = new List<ParameterDefinition>();
+        for (int i = 0; i < 10; i++)
+        {
+            parameters.Add(new ParameterDefinition(new StringName(""), VariantType.Int));
+        }
+        int parameterCount = parameters.Count;
+
+        var parametersNative = stackalloc GDExtensionPropertyInfo[parameterCount];
+        var parameterNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var parameterClassNamesNative = stackalloc NativeGodotStringName[parameterCount];
+        var parameterHintStringsNative = stackalloc NativeGodotString[parameterCount];
+
+        ClassRegistrationContext.ConvertSignalParameterInfosToNative(parameters, parametersNative, parameterNamesNative, parameterClassNamesNative, parameterHintStringsNative);
+
+        for (int i = 0; i < parameterCount; i++)
+        {
+            // Every parameter's pointers must point to that parameter's own slot.
+            Assert.Equal((nint)(&parameterNamesNative[i]), (nint)parametersNative[i].name);
+            Assert.Equal((nint)(&parameterClassNamesNative[i]), (nint)parametersNative[i].class_name);
+            Assert.Equal((nint)(&parameterHintStringsNative[i]), (nint)parametersNative[i].hint_string);
+
+            for (int j = i + 1; j < parameterCount; j++)
+            {
+                // The pointers of different parameters must be pairwise distinct.
+                Assert.NotEqual((nint)parametersNative[i].name, (nint)parametersNative[j].name);
+                Assert.NotEqual((nint)parametersNative[i].class_name, (nint)parametersNative[j].class_name);
+                Assert.NotEqual((nint)parametersNative[i].hint_string, (nint)parametersNative[j].hint_string);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When a `[BindMethod]`, virtual method override, or `[Signal]` is registered, its
managed parameter info is converted to the unmanaged `GDExtensionPropertyInfo`,
whose `name`, `class_name`, and `hint_string` are **pointers**. The engine reads
those pointers **later** only when `classdb_register_extension_class_method` /
`…_signal` / `…_virtual_method` is finally called at the end of the conversion.

The converted values were stored in **loop- and block-scoped locals**, and
their addresses (`&local`) were written into the property info:

```csharp
for (int i = 0; i < parameters.Count; i++)
{
    NativeGodotStringName parameterNameNative = parameter.Name.NativeValue.DangerousSelfRef;
    NativeGodotString hintStringNative = NativeGodotString.Create(parameter.HintString);
    args[i] = new GDExtensionPropertyInfo { name = &parameterNameNative, hint_string = &hintStringNative, ... };
}   // parameterNameNative / hintStringNative slots are reused next iteration
```

Every iteration reuses the same stack slots, so after the loop **all** parameters'
`args[i].name` (and `class_name`, `hint_string`, default value) alias the **last**
parameter's data. 

The return value info had the same defect one level down: its
struct was built inside a nested block, so its pointer fields dangled once that
block closed. 

A method/signal with more than one parameter registered with
corrupted per-parameter metadata (all parameters reporting the last one's name,
type hint, and default).

This affected all three registration paths: 
1. `BindMethod`
2. `BindSignal`
3. `BindVirtualMethod` (identical code)

Plus a companion leak: the `NativeGodotString` hint strings created during conversion were never disposed.

## Fix

Convert parameters into **parallel buffers with one slot per parameter**, so each
`GDExtensionPropertyInfo` points at its own stable slot that stays alive until
registration:

- `BindMethod` / `BindVirtualMethod` share a new `ConvertParameterInfosToNative`
  helper (per-index `stackalloc` slots for names, class names, hint strings, and
  default values).
- `BindSignal` gets `ConvertSignalParameterInfosToNative`. Its native slot types
  are `ref struct`s, so they can't use a managed array; it `stackalloc`s up to the
  existing span threshold and falls back to `NativeMemory.Alloc`/`Free` (in a
  `finally`) for larger signals.
- The return value info and the method name are hoisted into the registration
  frame for the same lifetime reason.
- The hint strings are disposed once, after registration (the engine has copied
  the data by then).

Virtual-method registration doesn't wire up default arguments, so that behavior
is unchanged as it reuses the shared helper and discards the optional-parameter
count.

## Verification

- **New unit tests** (`ClassRegistrationContextConversionTests`) exercise the
  extracted helpers with engine-free definitions and assert: (a) each parameter's
  pointers reference its **own** slot and are **pairwise distinct**; (b) default
  values dereference to the value of the parameter they belong to which are the exact
  things the aliasing bug corrupted; (c) the default-value array is **compacted**
  onto the trailing optional parameters when they follow a required one (a naive
  per-parameter-index write would fail this); and (d) the conversion holds up
  above the signal span threshold. Confirmed red/green on both the aliased-slot
  pattern and the naive-compaction pattern.
- `Godot.Bindings.Tests`: **205/205** pass (200 baseline + 5).
- `dotnet build src/Godot.Bindings` (trim/AOT analyzers on): no new IL or analyzer
  warnings as the only ones present are pre-existing and untouched (`IL2075` in
  `GodotObject.NativeName.cs`, `IL2090` in `Marshalling.cs`).

## Scope / known limitations

- Only empty `StringName`/`String` values can be constructed without a running
  Godot host (creating a non-empty one calls into the engine), so the unit tests
  assert on **pointer identity/distinctness** and on default values built from the
  interop-free `bool`/`int`/`float` Variant types. There is full end-to-end confirmation now
  that the engine reads back the correct per-parameter names, hints, and
  defaults for a registered class. This needs the Godot editor and the integration
  harness, which isn't exercised in CI here.
- `BindProperty` has a related but lower-confidence variant (a single property, no
  loop, so the risk is codegen-dependent stack-slot reuse of its block-scoped
  locals) plus the same hint-string leak. Left as a follow-up so every change here
  is a definite, test-backed fix.

### Deliberately left as-is (self-review notes)

A self-review surfaced a few lower-severity items that are intentionally **not**
changed here, to keep every edit a definite fix:

- **`BindSignal` native-memory (`> ParameterSpanThreshold`) branch is
  integration-only.** That branch's `NativeMemory.Alloc`/`Free` is inseparable from
  the `classdb_register_extension_class_signal` call, which needs a running editor;
  the added test covers the conversion helper above the threshold, but the heap
  alloc/free itself can only be exercised by integration.
- **Error-path hint-string disposal is best-effort.** On the happy path the native
  strings are disposed after registration; if a conversion or the native register
  call were to throw partway, strings created so far would not be disposed. That
  path aborts extension loading (fatal) and matches the surrounding code's existing
  behavior (e.g. `BindProperty` doesn't dispose its hint string at all). The one
  *reachable* trigger, an invalid optional/required parameter ordering is now
  validated up front, before any string is created, so it can't leak.
- **A few micro-allocations are intentional:** `BindSignal` keeps its fixed-size
  stack buffers even when it takes the heap path (the standard small-on-stack /
  large-on-heap idiom needs an unconditional stack buffer), and `BindVirtualMethod`
  reuses the shared parameter converter, so it passes default-value buffers the
  virtual path never reads. Both are negligible and favor sharing the tested helper
  over duplicating it.

This was found while auditing the registration path for adoption-blocking bugs. An issue was not
previously filed.
