### PR TITLE
Fix use-after-free returning a RefCounted from a ptr-called method

### DIFF
--- a/src/Godot.Bindings/NativeInterop/Marshallers/GodotObjectMarshaller.cs
+++ b/src/Godot.Bindings/NativeInterop/Marshallers/GodotObjectMarshaller.cs
@@ -104,6 +104,26 @@ internal unsafe class GodotObjectMarshaller
         *destination = GodotObject.GetNativePtr(value);
     }
 
+    /// <summary>
+    /// Writes a <see cref="RefCounted"/>-derived return value into an engine-side <c>Ref&lt;T&gt;</c>
+    /// slot for a ptrcall return. Unlike <see cref="WriteUnmanaged(nint*, GodotObject?)"/> (which
+    /// writes a raw object pointer, correct for <c>Object*</c> slots and for encoding arguments), a
+    /// <c>Ref&lt;T&gt;</c> return slot must be populated through <c>ref_set_object</c> so the engine
+    /// takes its own counted reference; writing the raw pointer would leave the engine with an
+    /// un-counted reference and free the object once the managed reference is released
+    /// (use-after-free). Mirrors godot-cpp's <c>PtrToArg&lt;Ref&lt;T&gt;&gt;::encode</c>.
+    /// </summary>
+    public static void WriteUnmanagedRefCounted(void* destination, GodotObject? value)
+    {
+        nint nativePtr = GodotObject.GetNativePtr(value);
+        if (nativePtr == 0)
+        {
+            // The engine's return slot starts as an unset (null) Ref<T>; leave it for a null return.
+            return;
+        }
+        GodotBridge.GDExtensionInterface.ref_set_object(destination, (void*)nativePtr);
+    }
+
     public static nint* ConvertToUnmanaged(GodotObject? value)
     {
         nint* ptr = (nint*)NativeMemory.Alloc((nuint)sizeof(nint));

--- a/src/Godot.Bindings/NativeInterop/Marshalling.Ptr.cs
+++ b/src/Godot.Bindings/NativeInterop/Marshalling.Ptr.cs
@@ -365,6 +365,14 @@ partial class Marshalling
 
         if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
         {
+            if (typeof(RefCounted).IsAssignableFrom(typeof(T)))
+            {
+                // A RefCounted-typed ptrcall return slot is an engine-side Ref<T> object; assign
+                // through ref_set_object so the engine holds its own counted reference. Writing the
+                // raw pointer (as the Object* branch does) would drop the reference (use-after-free).
+                GodotObjectMarshaller.WriteUnmanagedRefCounted(destination, UnsafeAs<GodotObject?>(value));
+                return;
+            }
             GodotObjectMarshaller.WriteUnmanaged((nint*)destination, UnsafeAs<GodotObject?>(value));
             return;
         }

--- a/tests/Godot.Bindings.IntegrationTests.TestGame/TestRefCounted.gd
+++ b/tests/Godot.Bindings.IntegrationTests.TestGame/TestRefCounted.gd
@@ -7,7 +7,15 @@ func _ready():
 	assert_equal(refcounted1.get_reference_count(), 1)
 
 	# Test getting the reference count on the GDScript side after crossing the interop boundary.
+	# The count is 2: the C# wrapper for the object created in create_from_csharp() holds one
+	# reference, and the engine's Ref<T> that received the ptrcall return holds another. Before
+	# the reference-counting fix the return dropped the engine's reference (leaving an un-counted
+	# reference held by GDScript), so this read 1 and the object could be freed out from under it.
 	var refcounted2 = TestRefCounted.create_from_csharp()
+	assert_equal(refcounted2.get_reference_count(), 2)
+	# Disposing the C# wrapper releases only its reference; the engine's counted reference survives,
+	# so the object is still alive at count 1 (this is exactly what the fix guarantees).
+	TestRefCounted.test_dispose_refcounted(refcounted2)
 	assert_equal(refcounted2.get_reference_count(), 1)
 
 	# Test getting the reference count on the C# side after crossing the interop boundary.


### PR DESCRIPTION
## Problem

When the engine **ptr-calls** a managed C# method that returns a `RefCounted`-derived object
(e.g. a typed GDScript call, or an engine virtual override), the return is written via
`MethodBindInvoker` → `Marshalling.WriteUnmanaged<TResult>(outRet, …)`, whose `GodotObject` arm wrote
the **raw object pointer** into the return slot:

```csharp
// GodotObjectMarshaller.WriteUnmanaged
*destination = GodotObject.GetNativePtr(value);
```

But per the engine's ptrcall contract, a `Ref<T>` **return** slot is a real `Ref<T>` object
([`method_ptrcall.h:287-289`](https://github.com/godotengine/godot/blob/master/core/variant/method_ptrcall.h#L287-L289):
*"p_ptr points to an EncodeT object which is a `Ref<T>` object"*), and it must be populated through
`ref_set_object`, which increments the reference count (`ref_set_object` → `Ref<T>::reference_ptr` →
`ref_pointer<true>` → `init_ref` → `reference`). A `Ref<T>` **argument** slot, by contrast, is a raw
`T*` — which is why writing a raw pointer looks fine for arguments but is wrong for returns.

Writing the raw pointer hands the engine an **un-counted** reference. Once the managed reference is
released, the object is freed while the engine — and any GDScript variable that received the return —
still points at it: **use-after-free**. (`ref_set_object` was already bound in the interop table but
was **never called anywhere** in the codebase, consistent with the bug.)

## Fix

Populate the `Ref<T>` return slot via `ref_set_object` for RefCounted-typed returns, mirroring
godot-cpp's canonical GDExtension encode
([`ref.hpp:246-255`](https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/classes/ref.hpp#L246-L255):
`if (p_val.is_valid()) ref_set_object(ref, p_val->_owner);`):

```csharp
if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
{
    if (typeof(RefCounted).IsAssignableFrom(typeof(T)))
    {
        GodotObjectMarshaller.WriteUnmanagedRefCounted(destination, UnsafeAs<GodotObject?>(value));
        return;
    }
    GodotObjectMarshaller.WriteUnmanaged((nint*)destination, UnsafeAs<GodotObject?>(value)); // Object* slot
    return;
}
```

The check is on the **static return type** `T` (JIT-constant-folded, like the surrounding
`IsAssignableFrom` checks) and `Marshalling.WriteUnmanaged<T>` is **return-only** — arguments encode
through `GodotObjectMarshaller.ConvertToUnmanaged` (a raw `T*` write, left untouched). Null returns
skip `ref_set_object`, leaving the engine's default-null `Ref<T>` (matching godot-cpp's `is_valid()`
guard).

## Reference-count protocol (why the integration assertion changes 1 → 2)

`GodotObject.Dispose` **unconditionally** calls `rc.Unreference()` for any RefCounted, so the
binding's invariant is *"every RefCounted C# wrapper owns exactly one counted reference."* A returned
RefCounted therefore cannot give away the wrapper's reference (that would break `Dispose`, and would
use-after-free a **shared** return such as a cached-resource getter) — the engine must take its **own**
reference. So a freshly created RefCounted returned across the boundary now has reference count **2**
(the C# wrapper + the engine's returned `Ref<T>`), settling to 1 when the wrapper is disposed. This is
the same semantic as the shipping in-tree mono integration (*"the managed instance also counts as a
reference"*) and is already codified by this very test file (`test_get_reference_count` asserts `== 2`
with a live wrapper, `== 3` through a Variant).

`TestRefCounted.gd`'s `create_from_csharp()` assertion expected **1** — the value produced by the
*dropped* reference. It is corrected to **2**, and pinned by then disposing the wrapper and asserting
the object is still alive at **1** (proving the engine's reference is real — the anti-UAF property).
No other assertion changes; all others already hold under the fix. In C++ the returned `Ref<T>`
temporary destructs to net the caller one reference; C# has one shared wrapper released on `Dispose`,
so the transient count is 2 by construction — no implementation can make that read 1 without either
re-introducing the UAF or corrupting shared returns.

## Verification

- `dotnet build src/Godot.Bindings` (trim/AOT analyzers on): builds clean, **no new IL or analyzer
  warnings** (only the two pre-existing baselines: `IL2075` in `GodotObject.NativeName.cs`, `IL2090`
  in `Marshalling.cs`).
- `Godot.Bindings.Tests`: **200/200** (no regression; the change is not exercised by the engine-free
  unit projects).
- **Integration behavior can't be exercised in this environment** — the ptrcall round-trip and the
  refcount/liveness assertions need a running Godot editor binary (the `IntegrationTests.TestGame`
  scene). The `TestRefCounted.gd` change is the regression guard: it fails under the bug (reads 1, or
  use-after-frees at the dispose→1 step) and passes with the fix. Confirming it on an editor build is
  the remaining check.

## Known limitation (pre-existing, shared with godot-cpp)

A method **declared** to return a non-RefCounted class (e.g. `GodotObject`) that returns a RefCounted
*instance* at runtime still under-counts: the encode dispatches on the static declared type, whose
slot is a raw `Object*` (not a `Ref<T>`), so `ref_set_object` is neither applicable nor callable
there. godot-cpp has the same declared-type dispatch; no current test hits it. Left as a follow-up.

Found while auditing the marshalling/registration path for adoption-blocking bugs; not previously filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
